### PR TITLE
Enable hosting on Microsoft.Owin.Testing.TestServer

### DIFF
--- a/PactNet/Mocks/MockHttpService/Nancy/MockProviderAdminRequestHandler.cs
+++ b/PactNet/Mocks/MockHttpService/Nancy/MockProviderAdminRequestHandler.cs
@@ -111,7 +111,6 @@ namespace PactNet.Mocks.MockHttpService.Nancy
         private void SetContent(string content, Stream stream)
         {
             var contentBytes = Encoding.UTF8.GetBytes(content);
-            stream.Position = 0;
             stream.Write(contentBytes, 0, contentBytes.Length);
             stream.Flush();
         }


### PR DESCRIPTION
- when running on the Microsoft Owin TestServer this stream seek was throwing as their
  response stream is not seekable.
