### PR TITLE
Updated to also use query string to match registered interactions.

### DIFF
--- a/PactNet.Tests/Mocks/MockHttpService/MockProviderRepositoryTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/MockProviderRepositoryTests.cs
@@ -97,7 +97,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         public void AddHandledRequest_WithHandledRequest_AddsHandledRequest()
         {
             var handledRequest = new HandledRequest(new ProviderServiceRequest(), new ProviderServiceInteraction());
-                                     
+
             var repo = GetSubject();
 
             repo.AddHandledRequest(handledRequest);
@@ -126,7 +126,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
                 },
                 Response = new ProviderServiceResponse
                 {
-                    Status = (int) HttpStatusCode.NoContent
+                    Status = (int)HttpStatusCode.NoContent
                 }
             };
 
@@ -198,6 +198,34 @@ namespace PactNet.Tests.Mocks.MockHttpService
             repo.AddInteraction(expectedInteraction);
 
             var interaction = repo.GetMatchingTestScopedInteraction(HttpVerb.Head, "/tester");
+
+            Assert.Equal(expectedInteraction, interaction);
+        }
+
+        [Fact]
+        public void GetMatchingTestScopedInteraction_WithOneMatchingTestScopedInteraction_WithQueryString()
+        {
+            var expectedInteraction = new ProviderServiceInteraction
+            {
+                Description = "My description",
+                Request = new ProviderServiceRequest
+                {
+                    Method = HttpVerb.Get,
+                    Path = "/tester",
+                    Query = "params=test"
+
+                },
+                Response = new ProviderServiceResponse
+                {
+                    Status = (int)HttpStatusCode.NoContent
+                }
+            };
+
+            var repo = GetSubject();
+
+            repo.AddInteraction(expectedInteraction);
+
+            var interaction = repo.GetMatchingTestScopedInteraction(HttpVerb.Get, "/tester?params=test");
 
             Assert.Equal(expectedInteraction, interaction);
         }

--- a/PactNet/Mocks/MockHttpService/IMockProviderRepository.cs
+++ b/PactNet/Mocks/MockHttpService/IMockProviderRepository.cs
@@ -11,7 +11,7 @@ namespace PactNet.Mocks.MockHttpService
 
         void AddInteraction(ProviderServiceInteraction interaction);
         void AddHandledRequest(HandledRequest handledRequest);
-        ProviderServiceInteraction GetMatchingTestScopedInteraction(HttpVerb method, string path);
+        ProviderServiceInteraction GetMatchingTestScopedInteraction(HttpVerb method, string pathWithQuery);
         void ClearHandledRequests();
         void ClearTestScopedInteractions();
     }

--- a/PactNet/Mocks/MockHttpService/MockProviderRepository.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderRepository.cs
@@ -55,7 +55,7 @@ namespace PactNet.Mocks.MockHttpService
             _handledRequests.Add(handledRequest);
         }
 
-        public ProviderServiceInteraction GetMatchingTestScopedInteraction(HttpVerb method, string path)
+        public ProviderServiceInteraction GetMatchingTestScopedInteraction(HttpVerb method, string pathWithQuery)
         {
             if (TestScopedInteractions == null || !TestScopedInteractions.Any())
             {
@@ -65,7 +65,7 @@ namespace PactNet.Mocks.MockHttpService
             var matchingInteractions = TestScopedInteractions.Where(x =>
                 x.Request != null &&
                 x.Request.Method == method &&
-                x.Request.Path == path).ToList();
+                x.Request.PathWithQuery() == pathWithQuery).ToList();
 
             if (matchingInteractions == null || !matchingInteractions.Any())
             {

--- a/PactNet/Mocks/MockHttpService/Nancy/MockProviderRequestHandler.cs
+++ b/PactNet/Mocks/MockHttpService/Nancy/MockProviderRequestHandler.cs
@@ -29,7 +29,7 @@ namespace PactNet.Mocks.MockHttpService.Nancy
         {
             var actualRequest = _requestMapper.Convert(context.Request);
 
-            var matchingInteraction = _mockProviderRepository.GetMatchingTestScopedInteraction(actualRequest.Method, actualRequest.Path);
+            var matchingInteraction = _mockProviderRepository.GetMatchingTestScopedInteraction(actualRequest.Method, actualRequest.PathWithQuery());
 
             _mockProviderRepository.AddHandledRequest(new HandledRequest(actualRequest, matchingInteraction));
 


### PR DESCRIPTION
We had multiple end points that we wanted to test and the path were the same and query string were different. I've made an update to match registered interactions if the query string also matches.
