### PR TITLE
Add custom reporters to pact verifier configuration

### DIFF
--- a/PactNet/PactVerifierConfig.cs
+++ b/PactNet/PactVerifierConfig.cs
@@ -1,14 +1,20 @@
+using System;
+using System.Collections.Generic;
+
 namespace PactNet
 {
     public class PactVerifierConfig
     {
         public string LogDir { get; set; }
 
+        public IEnumerable<Action<string>> Reporters { get; set; }
+
         internal string LoggerName;
 
         public PactVerifierConfig()
         {
             LogDir = Constants.DefaultLogDir;
+            Reporters = new List<Action<string>>();
         }
     }
 }

--- a/PactNet/Reporters/Reporter.cs
+++ b/PactNet/Reporters/Reporter.cs
@@ -26,7 +26,7 @@ namespace PactNet.Reporters
             {
                 Console.WriteLine, 
                 new FileReportOutputter(config.LoggerName).Write
-            })
+            }.Concat(config.Reporters).ToList())
         {
         }
 

--- a/Samples/EventApi/Provider.Api.Web.Tests/EventAPITests.cs
+++ b/Samples/EventApi/Provider.Api.Web.Tests/EventAPITests.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Owin.Testing;
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Owin.Testing;
 using PactNet;
 using Xunit;
 
@@ -9,8 +11,16 @@ namespace Provider.Api.Web.Tests
         [Fact]
         public void EnsureEventApiHonoursPactWithConsumer()
         {
+            string output = string.Empty;
+
             //Arrange
-            IPactVerifier pactVerifier = new PactVerifier(() => {}, () => {});
+            IPactVerifier pactVerifier = new PactVerifier(() => {}, () => {}, new PactVerifierConfig
+            {
+                Reporters = new List<Action<string>>
+                {
+                    x => output += x
+                }
+            });
 
             pactVerifier
                 .ProviderState(
@@ -30,6 +40,9 @@ namespace Provider.Api.Web.Tests
                    .PactUri("../../../Consumer.Tests/pacts/consumer-event_api.json")
                    .Verify();
             }
+
+            // Verify that verifaction log is also sent to additional reporters defined in the config
+            Assert.Contains("Verifying a Pact between Consumer and Event API", output);
         }
 
         private void EnsureOneDetailsViewEventExists()


### PR DESCRIPTION
When using xunit 2 the verification log sent to the standard output isn't captured. I can work around this by setting Console.Out to something which writes to an xunit ITestOutputHelper and then putting it back to the original once the test is complete - but that doesn't play well with tests running in parallel.

So, I've added a config setting that allows adding additional reporters to be set. As the existing tests use the internal constructors that don't use the config object I've added a usage to the samples. Let me know if anything else is needed/more desirable.