### PR TITLE
Value agnostic http body matcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Build/PactNet*.nupkg
 !packages/repositories.config
 /Build/coverage
 [Ll]ogs
+.vs/

--- a/PactNet.Tests/Mocks/MockHttpService/Comparers/ProviderServiceResponseComparerTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Comparers/ProviderServiceResponseComparerTests.cs
@@ -379,6 +379,39 @@ namespace PactNet.Tests.Mocks.MockHttpService.Comparers
         }
 
         [Fact]
+        public void Compare_ValueAgnostic_WithNonMatchingObject_OneErrorIsAddedToTheComparisonResult()
+        {
+            var expected = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new
+                {
+                    myString = "Tester",
+                    myInt = 1,
+                    myGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C"),
+                    myDouble = 2.0
+                }
+            };
+
+            var actual = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new
+                {
+                    myString = "Tester",
+                    MyInt = 1,
+                    MyGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C")
+                }
+            };
+
+            var comparer = GetSubject();
+
+            var result = comparer.Compare(expected, actual);
+
+            Assert.Equal(1, result.Failures.Count());
+        }
+
+        [Fact]
         public void Compare_WithMatchingObjectAndANonMatchingValue_OneErrorIsAddedToTheComparisonResult()
         {
             var expected = new ProviderServiceResponse
@@ -411,7 +444,71 @@ namespace PactNet.Tests.Mocks.MockHttpService.Comparers
         }
 
         [Fact]
+        public void Compare_ValueAgnostic_WithMatchingObjectAndANonMatchingValue_NoErrorsAreAddedToTheComparisonResult()
+        {
+            var expected = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new
+                {
+                    myString = "Tester",
+                    myInt = 1,
+                    myGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C")
+                }
+            };
+
+            var actual = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new
+                {
+                    myString = "Tester2",
+                    myInt = 1,
+                    myGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C")
+                }
+            };
+
+            var comparer = GetSubject();
+
+            var result = comparer.Compare(expected, actual, true);
+
+            Assert.Equal(0, result.Failures.Count());
+        }
+
+        [Fact]
         public void Compare_WithMatchingObjectHoweverPropertyNameCasingIsDifferent_OneErrorIsAddedToTheComparisonResult()
+        {
+            var expected = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new
+                {
+                    MyString = "Tester",
+                    MyInt = 1,
+                    MyGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C")
+                }
+            };
+
+            var actual = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new
+                {
+                    myString = "Tester",
+                    myInt = 1,
+                    myGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C")
+                }
+            };
+
+            var comparer = GetSubject();
+
+            var result = comparer.Compare(expected, actual);
+
+            Assert.Equal(1, result.Failures.Count());
+        }
+
+        [Fact]
+        public void Compare_ValueAgnostic_WithMatchingObjectHoweverPropertyNameCasingIsDifferent_OneErrorIsAddedToTheComparisonResult()
         {
             var expected = new ProviderServiceResponse
             {
@@ -542,6 +639,44 @@ namespace PactNet.Tests.Mocks.MockHttpService.Comparers
             var result = comparer.Compare(expected, actual);
 
             Assert.Equal(1, result.Failures.Count());
+        }
+
+        [Fact]
+        public void Compare_VAlueAgnostic_WithNonMatchingCollection_NoErrorsAreAddedToTheComparisonResult()
+        {
+            var expected = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new List<dynamic>
+                {
+                    new
+                    {
+                        myString = "Tester",
+                        myInt = 1,
+                        myGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C")
+                    }
+                }
+            };
+
+            var actual = new ProviderServiceResponse
+            {
+                Status = 201,
+                Body = new List<dynamic>
+                {
+                    new
+                    {
+                        myString = "Tester2",
+                        myInt = 1,
+                        myGuid = Guid.Parse("EEB517E6-AC8B-414A-A0DB-6147EAD9193C")
+                    }
+                }
+            };
+
+            var comparer = GetSubject();
+
+            var result = comparer.Compare(expected, actual, true);
+
+            Assert.Equal(0, result.Failures.Count());
         }
     }
 }

--- a/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
@@ -98,6 +98,43 @@ namespace PactNet.Tests.Mocks.MockHttpService
         }
 
         [Fact]
+        public void Given_WithValueAgnosticBodyComparison_SetsValueAgnosticBodyComparison()
+        {
+            string ANY_STRING = "blah";
+            var mockService = GetSubject();
+            mockService.Start();
+
+            mockService
+                .Given(ANY_STRING)
+                .UponReceiving(ANY_STRING)
+                .With(new ProviderServiceRequest { Method = HttpVerb.Get })
+                .WithValueAgnosticBodyComparison()
+                .WillRespondWith(new ProviderServiceResponse { Status = (int)HttpStatusCode.OK });
+
+            var interaction = Deserialise<ProviderServiceInteraction>(_fakeHttpMessageHandler.RequestContentRecieved.Single());
+
+            Assert.Equal(true, interaction.ValueAgnosticBodyComparison);
+        }
+
+        [Fact]
+        public void Given_WithoutValueAgnosticBodyComparison_DefaultsValueAgnosticBodyComparisonToFalse()
+        {
+            string ANY_STRING = "blah";
+            var mockService = GetSubject();
+            mockService.Start();
+
+            mockService
+                .Given(ANY_STRING)
+                .UponReceiving(ANY_STRING)
+                .With(new ProviderServiceRequest { Method = HttpVerb.Get })
+                .WillRespondWith(new ProviderServiceResponse { Status = (int)HttpStatusCode.OK });
+
+            var interaction = Deserialise<ProviderServiceInteraction>(_fakeHttpMessageHandler.RequestContentRecieved.Single());
+
+            Assert.Equal(false, interaction.ValueAgnosticBodyComparison);
+        }
+
+        [Fact]
         public void UponReceiving_WithDescription_SetsDescription()
         {
             const string description = "My description";

--- a/PactNet.Tests/PactNet.Tests.csproj
+++ b/PactNet.Tests/PactNet.Tests.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Mocks\MockHttpService\Mappers\NancyResponseMapperTests.cs" />
     <Compile Include="Mocks\MockHttpService\Mappers\ProviderServiceRequestMapperTests.cs" />
     <Compile Include="Mocks\MockHttpService\Mappers\ProviderServiceResponseMapperTests.cs" />
+    <Compile Include="Mocks\MockHttpService\Matchers\JValueMatcherTests.cs" />
     <Compile Include="Mocks\MockHttpService\MockProviderRepositoryTests.cs" />
     <Compile Include="Mocks\MockHttpService\Models\ProviderServiceInteractionTests.cs" />
     <Compile Include="Mocks\MockHttpService\Models\ProviderServiceResponseTests.cs" />

--- a/PactNet.Tests/PactNet.Tests.csproj
+++ b/PactNet.Tests/PactNet.Tests.csproj
@@ -118,7 +118,6 @@
     <Compile Include="Mocks\MockHttpService\Mappers\NancyResponseMapperTests.cs" />
     <Compile Include="Mocks\MockHttpService\Mappers\ProviderServiceRequestMapperTests.cs" />
     <Compile Include="Mocks\MockHttpService\Mappers\ProviderServiceResponseMapperTests.cs" />
-    <Compile Include="Mocks\MockHttpService\Matchers\JValueMatcherTests.cs" />
     <Compile Include="Mocks\MockHttpService\MockProviderRepositoryTests.cs" />
     <Compile Include="Mocks\MockHttpService\Models\ProviderServiceInteractionTests.cs" />
     <Compile Include="Mocks\MockHttpService\Models\ProviderServiceResponseTests.cs" />

--- a/PactNet/Mocks/MockHttpService/Comparers/IProviderServiceResponseComparer.cs
+++ b/PactNet/Mocks/MockHttpService/Comparers/IProviderServiceResponseComparer.cs
@@ -5,5 +5,6 @@ namespace PactNet.Mocks.MockHttpService.Comparers
 {
     internal interface IProviderServiceResponseComparer : IComparer<ProviderServiceResponse>
     {
+        ComparisonResult Compare(ProviderServiceResponse expected, ProviderServiceResponse actual, bool valueAgnosticBodyComparison);
     }
 }

--- a/PactNet/Mocks/MockHttpService/Comparers/ProviderServiceResponseComparer.cs
+++ b/PactNet/Mocks/MockHttpService/Comparers/ProviderServiceResponseComparer.cs
@@ -51,7 +51,6 @@ namespace PactNet.Mocks.MockHttpService.Comparers
                     { DefaultHttpBodyMatcher.Path, new DefaultHttpBodyMatcher(valueAgnosticBodyComparison ? (IJValueMatcher) new JValueValueAgnosticMatcher() : new JValueMatcher(), true) }
                 };
 
-                //var bodyResult = _httpBodyComparer.Compare(expected.Body, actual.Body, expected.MatchingRules);
                 var bodyResult = _httpBodyComparer.Compare(expected.Body, actual.Body, matchingRules);
                 result.AddChildResult(bodyResult);
             }

--- a/PactNet/Mocks/MockHttpService/Comparers/ProviderServiceResponseComparer.cs
+++ b/PactNet/Mocks/MockHttpService/Comparers/ProviderServiceResponseComparer.cs
@@ -1,6 +1,9 @@
 ﻿using System.Linq;
 using PactNet.Comparers;
 using PactNet.Mocks.MockHttpService.Models;
+using PactNet.Matchers;
+using System.Collections.Generic;
+using PactNet.Mocks.MockHttpService.Matchers;
 
 namespace PactNet.Mocks.MockHttpService.Comparers
 {
@@ -18,6 +21,11 @@ namespace PactNet.Mocks.MockHttpService.Comparers
         }
 
         public ComparisonResult Compare(ProviderServiceResponse expected, ProviderServiceResponse actual)
+        {
+            return Compare(expected, actual, false);
+        }
+        
+        public ComparisonResult Compare(ProviderServiceResponse expected, ProviderServiceResponse actual, bool valueAgnosticBodyComparison)
         {
             var result = new ComparisonResult("returns a response which");
 
@@ -38,7 +46,13 @@ namespace PactNet.Mocks.MockHttpService.Comparers
 
             if (expected.Body != null)
             {
-                var bodyResult = _httpBodyComparer.Compare(expected.Body, actual.Body, expected.MatchingRules);
+                var matchingRules = new Dictionary<string, IMatcher>
+                {
+                    { DefaultHttpBodyMatcher.Path, new DefaultHttpBodyMatcher(valueAgnosticBodyComparison ? (IJValueMatcher) new JValueValueAgnosticMatcher() : new JValueMatcher(), true) }
+                };
+
+                //var bodyResult = _httpBodyComparer.Compare(expected.Body, actual.Body, expected.MatchingRules);
+                var bodyResult = _httpBodyComparer.Compare(expected.Body, actual.Body, matchingRules);
                 result.AddChildResult(bodyResult);
             }
             else if (expected.Body == null && 

--- a/PactNet/Mocks/MockHttpService/IMockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/IMockProviderService.cs
@@ -6,6 +6,7 @@ namespace PactNet.Mocks.MockHttpService
     public interface IMockProviderService : IMockProvider<IMockProviderService>
     {
         IMockProviderService With(ProviderServiceRequest request);
+        IMockProviderService WithValueAgnosticBodyComparison();
         void WillRespondWith(ProviderServiceResponse response);
         void Start();
         void Stop();

--- a/PactNet/Mocks/MockHttpService/Matchers/DefaultHttpBodyMatcher.cs
+++ b/PactNet/Mocks/MockHttpService/Matchers/DefaultHttpBodyMatcher.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using PactNet.Matchers;
+using System.Diagnostics.Contracts;
 
 namespace PactNet.Mocks.MockHttpService.Matchers
 {
@@ -10,9 +11,13 @@ namespace PactNet.Mocks.MockHttpService.Matchers
         public const string Path = "$..*";
 
         public bool AllowExtraKeys { get; private set; }
+        public IJValueMatcher JValueMatcher { get; }
 
-        public DefaultHttpBodyMatcher(bool allowExtraKeysInObjects)
+        public DefaultHttpBodyMatcher(IJValueMatcher jValueMatcher, bool allowExtraKeysInObjects)
         {
+            Contract.Requires(jValueMatcher != null);
+
+            JValueMatcher = jValueMatcher;
             AllowExtraKeys = allowExtraKeysInObjects;
         }
 
@@ -20,7 +25,7 @@ namespace PactNet.Mocks.MockHttpService.Matchers
         {
             if (expected is JValue)
             {
-                return actual != null && expected.Equals(actual) ?
+                return JValueMatcher.Match((JValue) expected, actual) ? //  actual != null && expected.Equals(actual) ?
                     new MatcherResult(new SuccessfulMatcherCheck(path)) :
                     new MatcherResult(new FailedMatcherCheck(path, MatcherCheckFailureType.ValueDoesNotMatch));
             }
@@ -52,7 +57,7 @@ namespace PactNet.Mocks.MockHttpService.Matchers
                 {
                     var actualToken = actual.SelectToken(expectedToken.Path);
 
-                    if (actualToken != null && expectedToken.Equals(actualToken))
+                    if (JValueMatcher.Match((JValue) expectedToken, actualToken)) //(actualToken != null && expectedToken.Equals(actualToken))
                     {
                         checks.Add(new SuccessfulMatcherCheck(expectedToken.Path));
                     }

--- a/PactNet/Mocks/MockHttpService/Matchers/DefaultHttpBodyMatcher.cs
+++ b/PactNet/Mocks/MockHttpService/Matchers/DefaultHttpBodyMatcher.cs
@@ -25,7 +25,7 @@ namespace PactNet.Mocks.MockHttpService.Matchers
         {
             if (expected is JValue)
             {
-                return JValueMatcher.Match((JValue) expected, actual) ? //  actual != null && expected.Equals(actual) ?
+                return JValueMatcher.Match((JValue) expected, actual) ? 
                     new MatcherResult(new SuccessfulMatcherCheck(path)) :
                     new MatcherResult(new FailedMatcherCheck(path, MatcherCheckFailureType.ValueDoesNotMatch));
             }
@@ -57,7 +57,7 @@ namespace PactNet.Mocks.MockHttpService.Matchers
                 {
                     var actualToken = actual.SelectToken(expectedToken.Path);
 
-                    if (JValueMatcher.Match((JValue) expectedToken, actualToken)) //(actualToken != null && expectedToken.Equals(actualToken))
+                    if (JValueMatcher.Match((JValue) expectedToken, actualToken))
                     {
                         checks.Add(new SuccessfulMatcherCheck(expectedToken.Path));
                     }

--- a/PactNet/Mocks/MockHttpService/Matchers/IJValueMatcher.cs
+++ b/PactNet/Mocks/MockHttpService/Matchers/IJValueMatcher.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PactNet.Mocks.MockHttpService.Matchers
+{
+    public interface IJValueMatcher
+    {
+        bool Match(JValue expected, JToken actual);
+    }
+}

--- a/PactNet/Mocks/MockHttpService/Matchers/JValueMatcher.cs
+++ b/PactNet/Mocks/MockHttpService/Matchers/JValueMatcher.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace PactNet.Mocks.MockHttpService.Matchers
+{
+    public class JValueMatcher : IJValueMatcher
+    {
+        public bool Match(JValue expected, JToken actual)
+        {
+            return actual != null && expected.Equals(actual);
+        }
+    }
+}

--- a/PactNet/Mocks/MockHttpService/Matchers/JValueValueAgnosticMatcher.cs
+++ b/PactNet/Mocks/MockHttpService/Matchers/JValueValueAgnosticMatcher.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PactNet.Mocks.MockHttpService.Matchers
+{
+    public class JValueValueAgnosticMatcher : IJValueMatcher
+    {
+        public bool Match(JValue expected, JToken actual)
+        {
+            return actual != null;
+        }
+    }
+}

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -24,6 +24,7 @@ namespace PactNet.Mocks.MockHttpService
         private string _description;
         private ProviderServiceRequest _request;
         private ProviderServiceResponse _response;
+        private bool _valueAgnosticValueComparison;
 
         public string BaseUri { get; private set; }
 
@@ -38,11 +39,12 @@ namespace PactNet.Mocks.MockHttpService
             BaseUri = String.Format("{0}://localhost:{1}", enableSsl ? "https" : "http", port);
             _httpClient = httpClientFactory(BaseUri);
             _httpMethodMapper = httpMethodMapper;
+            _valueAgnosticValueComparison = false;
         }
 
         public MockProviderService(int port, bool enableSsl, string providerName, PactConfig config)
             : this(
-            baseUri => new NancyHttpHost(baseUri, providerName, config), 
+            baseUri => new NancyHttpHost(baseUri, providerName, config),
             port,
             enableSsl,
             baseUri => new HttpClient { BaseAddress = new Uri(baseUri) },
@@ -92,7 +94,14 @@ namespace PactNet.Mocks.MockHttpService
             }
 
             _request = request;
-            
+
+            return this;
+        }
+
+        public IMockProviderService WithValueAgnosticBodyComparison()
+        {
+            _valueAgnosticValueComparison = true;
+
             return this;
         }
 
@@ -209,7 +218,8 @@ namespace PactNet.Mocks.MockHttpService
                 ProviderState = _providerState,
                 Description = _description,
                 Request = _request,
-                Response = _response
+                Response = _response,
+                ValueAgnosticBodyComparison = _valueAgnosticValueComparison
             };
 
             var testContext = BuildTestContext();

--- a/PactNet/Mocks/MockHttpService/Models/ProviderServiceRequest.cs
+++ b/PactNet/Mocks/MockHttpService/Models/ProviderServiceRequest.cs
@@ -51,7 +51,7 @@ namespace PactNet.Mocks.MockHttpService.Models
         {
             MatchingRules = new Dictionary<string, IMatcher>
             {
-                { DefaultHttpBodyMatcher.Path, new DefaultHttpBodyMatcher(false) }
+                { DefaultHttpBodyMatcher.Path, new DefaultHttpBodyMatcher(new JValueMatcher(), false) }
             };
 
             return body;

--- a/PactNet/Mocks/MockHttpService/Models/ProviderServiceResponse.cs
+++ b/PactNet/Mocks/MockHttpService/Models/ProviderServiceResponse.cs
@@ -43,7 +43,7 @@ namespace PactNet.Mocks.MockHttpService.Models
         {
             MatchingRules = new Dictionary<string, IMatcher>
             {
-                { DefaultHttpBodyMatcher.Path, new DefaultHttpBodyMatcher(true) }
+                { DefaultHttpBodyMatcher.Path, new DefaultHttpBodyMatcher(new JValueMatcher(), true) }
             };
 
             return body;

--- a/PactNet/Mocks/MockHttpService/Models/ProviderServiceResponse.cs
+++ b/PactNet/Mocks/MockHttpService/Models/ProviderServiceResponse.cs
@@ -18,10 +18,6 @@ namespace PactNet.Mocks.MockHttpService.Models
         [JsonConverter(typeof(PreserveCasingDictionaryConverter))]
         public IDictionary<string, string> Headers { get; set; }
 
-        [JsonIgnore]
-        [JsonProperty(PropertyName = "matchingRules")]
-        internal IDictionary<string, IMatcher> MatchingRules { get; private set; }
-
         [JsonProperty(PropertyName = "body", NullValueHandling = NullValueHandling.Include)]
         public dynamic Body
         {
@@ -29,7 +25,7 @@ namespace PactNet.Mocks.MockHttpService.Models
             set
             {
                 _bodyWasSet = true;
-                _body = ParseBodyMatchingRules(value);
+                _body = value;
             }
         }
 
@@ -37,16 +33,6 @@ namespace PactNet.Mocks.MockHttpService.Models
         public bool ShouldSerializeBody()
         {
             return _bodyWasSet;
-        }
-
-        private dynamic ParseBodyMatchingRules(dynamic body)
-        {
-            MatchingRules = new Dictionary<string, IMatcher>
-            {
-                { DefaultHttpBodyMatcher.Path, new DefaultHttpBodyMatcher(new JValueMatcher(), true) }
-            };
-
-            return body;
         }
     }
 }

--- a/PactNet/Mocks/MockHttpService/Validators/ProviderServiceValidator.cs
+++ b/PactNet/Mocks/MockHttpService/Validators/ProviderServiceValidator.cs
@@ -135,7 +135,7 @@ namespace PactNet.Mocks.MockHttpService.Validators
             var expectedResponse = interaction.Response;
             var actualResponse = _httpRequestSender.Send(interaction.Request);
 
-            return _providerServiceResponseComparer.Compare(expectedResponse, actualResponse);
+            return _providerServiceResponseComparer.Compare(expectedResponse, actualResponse, interaction.ValueAgnosticBodyComparison);
         }
 
         private void InvokePactSetUpIfApplicable(ProviderStates providerStates)

--- a/PactNet/Models/Interaction.cs
+++ b/PactNet/Models/Interaction.cs
@@ -5,6 +5,11 @@ namespace PactNet.Models
 {
     public class Interaction
     {
+        public Interaction()
+        {
+            ValueAgnosticBodyComparison = false;
+        }
+
         private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings
         {
             NullValueHandling = NullValueHandling.Ignore,
@@ -21,6 +26,9 @@ namespace PactNet.Models
         //public string provider_state { set { ProviderState = value; } } //Uncomment when provider_state becomes providerState
         [Obsolete("For forwards compatibility.")]
         public string providerState { set { ProviderState = value; } } //Remove when provider_state becomes providerState 
+
+        [JsonProperty(PropertyName = "valueAgnosticBodyComparison")]
+        public bool ValueAgnosticBodyComparison { get; set; }
 
         public string AsJsonString()
         {

--- a/PactNet/PactNet.csproj
+++ b/PactNet/PactNet.csproj
@@ -126,6 +126,9 @@
     <Compile Include="Mocks\MockHttpService\Configuration\NancyConfig.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Mocks\MockHttpService\IHttpHost.cs" />
+    <Compile Include="Mocks\MockHttpService\Matchers\IJValueMatcher.cs" />
+    <Compile Include="Mocks\MockHttpService\Matchers\JValueMatcher.cs" />
+    <Compile Include="Mocks\MockHttpService\Matchers\JValueValueAgnosticMatcher.cs" />
     <Compile Include="Mocks\MockHttpService\Models\IHttpMessage.cs" />
     <Compile Include="Mocks\MockHttpService\Nancy\NancyHttpHost.cs" />
     <Compile Include="Mocks\MockHttpService\Nancy\IMockProviderAdminRequestHandler.cs" />


### PR DESCRIPTION
HI there

I have added the ability for the client to specify that it does not care about the property values (JValues) in the response body, but that it still cares that the existence of the properties. This makes our tests simpler to setup and more robust.

Being as this is specified by the client, I had to modify the json PactFile format, which I realise might be controversial, but the new value is optional and defaults to the existing behaviour so hopefully it won't be a big deal.

The new property might ideally go on the body / ProviderServiceResponse.Body properties, but this would result in a reserved property name, so it has gone on the Interaction object instead. This also removed the mild hack of creating MatchingRules while deserialising ProviderServiceResponse.Body. I have added an overload of Compare to IProviderServiceResponseComparer, which is mildly suboptimal and means that you would lose the value agnostic functionality if treating it as an IComparer. However nothing does this and there doesn't seem to be any reason why anything would, so I don't think its a problem.

I have packaged this change up as v1.1.2 and added it to our internal NuGet feed, so if you decide not to accept this pull request, could you do us a favour and jump to version 1.1.3 when you next release?

Thanks

Cedd