### PR TITLE
Fixing the dropping of Content-Type header parameters when verifying …

### DIFF
--- a/PactNet.Tests/Mocks/MockHttpService/Mappers/HttpContentMapperTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Mappers/HttpContentMapperTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using PactNet.Mocks.MockHttpService.Mappers;
 using PactNet.Mocks.MockHttpService.Models;
@@ -32,6 +34,22 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
             var result = mapper.Convert(httpBodyContent);
 
             Assert.Empty(result.ReadAsStringAsync().Result);
+        }
+
+        [Fact]
+        public void Convert_WithContentTypeContainingParameter_ReturnsContentWithContentTypeHeader()
+        {
+            const string contentType = "text/plain";
+            const string content = "test";
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(content), contentType: contentType + "; version=1", encoding: Encoding.UTF8);
+            IHttpContentMapper mapper = GetSubject();
+
+            HttpContent result = mapper.Convert(httpBodyContent);
+
+            Assert.Equal(contentType, result.Headers.ContentType.MediaType);
+            Assert.Contains(new NameValueHeaderValue("version", "1"), result.Headers.ContentType.Parameters);
+            Assert.Equal("utf-8", result.Headers.ContentType.CharSet);
+            Assert.Equal(content, result.ReadAsStringAsync().Result);
         }
     }
 }

--- a/PactNet/Mocks/MockHttpService/Mappers/HttpContentMapper.cs
+++ b/PactNet/Mocks/MockHttpService/Mappers/HttpContentMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Net.Http.Headers;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet.Mocks.MockHttpService.Mappers
@@ -12,7 +13,12 @@ namespace PactNet.Mocks.MockHttpService.Mappers
                 return null;
             }
 
-            return new StringContent(from.Content, from.Encoding, from.ContentType);
+            var stringContent = new StringContent(from.Content, from.Encoding);
+
+            stringContent.Headers.ContentType = MediaTypeHeaderValue.Parse(from.ContentType);
+            stringContent.Headers.ContentType.CharSet = from.Encoding.WebName;
+
+            return stringContent;
         }
     }
 }


### PR DESCRIPTION
The Verifier drops parameters from the Content-Type header, e.g. the header `application/json; version=1; charset=utf-8` would currently be submitted as `application/json; charset=utf-8`.  (Pacts are generated correctly by the Builder though when the Content-Type header contains parameters)