### PR TITLE
disable Nancy's default status code handler

### DIFF
--- a/PactNet/Mocks/MockHttpService/Nancy/MockProviderNancyBootstrapper.cs
+++ b/PactNet/Mocks/MockHttpService/Nancy/MockProviderNancyBootstrapper.cs
@@ -31,6 +31,7 @@ namespace PactNet.Mocks.MockHttpService.Nancy
                 return NancyInternalConfiguration.WithOverrides(c =>
                 {
                     c.RequestDispatcher = typeof(MockProviderNancyRequestDispatcher);
+                    c.StatusCodeHandlers.Clear();
                 });
             }
         }


### PR DESCRIPTION
disable Nancy's default status code handler so 404 and 500 responses aren't clobbered (https://github.com/NancyFx/Nancy/blob/master/src/Nancy/ErrorHandling/DefaultStatusCodeHandler.cs)