### PR TITLE
Add rewriteLocalhost overload for disabling netsh localhost binding s…

### DIFF
--- a/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
@@ -19,7 +19,7 @@ namespace PactNet.Tests.IntegrationTests
             var pactConfig = new PactConfig();
             pactConfig.LoggerName = "my_api";
 
-            PactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) => 
+            PactBuilder = new PactBuilder((port, enableSsl, providerName, bindOnAllAdapters) => 
                     new MockProviderService(
                         baseUri => new NancyHttpHost(baseUri, pactConfig, new IntegrationTestingMockProviderNancyBootstrapper(pactConfig)), 
                         port, enableSsl, 

--- a/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
@@ -19,7 +19,7 @@ namespace PactNet.Tests.IntegrationTests
             var pactConfig = new PactConfig();
             pactConfig.LoggerName = "my_api";
 
-            PactBuilder = new PactBuilder((port, enableSsl, providerName) => 
+            PactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => 
                     new MockProviderService(
                         baseUri => new NancyHttpHost(baseUri, pactConfig, new IntegrationTestingMockProviderNancyBootstrapper(pactConfig)), 
                         port, enableSsl, 

--- a/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
@@ -19,7 +19,7 @@ namespace PactNet.Tests.IntegrationTests
             var pactConfig = new PactConfig();
             pactConfig.LoggerName = "my_api";
 
-            PactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => 
+            PactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) => 
                     new MockProviderService(
                         baseUri => new NancyHttpHost(baseUri, pactConfig, new IntegrationTestingMockProviderNancyBootstrapper(pactConfig)), 
                         port, enableSsl, 

--- a/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
@@ -19,7 +19,7 @@ namespace PactNet.Tests.IntegrationTests
             var pactConfig = new PactConfig();
             pactConfig.LoggerName = "my_api";
 
-            PactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
+            PactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) =>
                     new MockProviderService(
                         baseUri => new NancyHttpHost(baseUri, pactConfig, new IntegrationTestingMockProviderNancyBootstrapper(pactConfig)),
                         port, enableSsl,

--- a/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
@@ -19,7 +19,7 @@ namespace PactNet.Tests.IntegrationTests
             var pactConfig = new PactConfig();
             pactConfig.LoggerName = "my_api";
 
-            PactBuilder = new PactBuilder((port, enableSsl, providerName) =>
+            PactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
                     new MockProviderService(
                         baseUri => new NancyHttpHost(baseUri, pactConfig, new IntegrationTestingMockProviderNancyBootstrapper(pactConfig)),
                         port, enableSsl,

--- a/PactNet.Tests/PactBuilderTests.cs
+++ b/PactNet.Tests/PactBuilderTests.cs
@@ -75,7 +75,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) => mockMockProviderService);
 
             var mockProviderService = pactBuilder.MockService(1234);
 
@@ -88,7 +88,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) => mockMockProviderService);
 
             pactBuilder.MockService(1234);
             mockMockProviderService.Received(0).Stop();
@@ -103,7 +103,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -120,7 +120,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -137,7 +137,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -154,7 +154,7 @@ namespace PactNet.Tests
             var serializerSettings = new JsonSerializerSettings();
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) => mockMockProviderService);
 
             pactBuilder.MockService(1234, serializerSettings);
 
@@ -173,7 +173,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) => mockMockProviderService);
 
             pactBuilder.MockService(1234);
 
@@ -191,7 +191,7 @@ namespace PactNet.Tests
         [Fact]
         public void Build_WhenCalledWithoutConsumerNameSet_ThrowsInvalidOperationException()
         {
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, rewriteLocalhost, providerName) => Substitute.For<IMockProviderService>());
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, bindOnAllAdapters, providerName) => Substitute.For<IMockProviderService>());
             pactBuilder.MockService(1234);
             pactBuilder
                 .HasPactWith("Event API");
@@ -202,7 +202,7 @@ namespace PactNet.Tests
         [Fact]
         public void Build_WhenCalledWithoutProviderNameSet_ThrowsInvalidOperationException()
         {
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, rewriteLocalhost, providerName) => Substitute.For<IMockProviderService>());
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, bindOnAllAdapters, providerName) => Substitute.For<IMockProviderService>());
             pactBuilder.MockService(1234);
             pactBuilder
                 .ServiceConsumer("Event Client");
@@ -217,7 +217,7 @@ namespace PactNet.Tests
             const string providerName = "Event API";
             var mockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, rewriteLocalhost, provider) => mockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, bindOnAllAdapters, provider) => mockProviderService);
             pactBuilder.MockService(1234);
             pactBuilder
                 .ServiceConsumer(consumerName)
@@ -233,7 +233,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService)
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, bindOnAllAdapters, providerName) => mockMockProviderService)
                 .ServiceConsumer("Event Client")
                 .HasPactWith("Event API");
 

--- a/PactNet.Tests/PactBuilderTests.cs
+++ b/PactNet.Tests/PactBuilderTests.cs
@@ -75,7 +75,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
 
             var mockProviderService = pactBuilder.MockService(1234);
 
@@ -88,7 +88,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
 
             pactBuilder.MockService(1234);
             mockMockProviderService.Received(0).Stop();
@@ -103,7 +103,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -120,7 +120,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -137,7 +137,7 @@ namespace PactNet.Tests
             var calledWithSslEnabled = false;
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) =>
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) =>
             {
                 calledWithSslEnabled = enableSsl;
                 return mockMockProviderService;
@@ -154,7 +154,7 @@ namespace PactNet.Tests
             var serializerSettings = new JsonSerializerSettings();
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
 
             pactBuilder.MockService(1234, serializerSettings);
 
@@ -173,7 +173,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) => mockMockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService);
 
             pactBuilder.MockService(1234);
 
@@ -191,7 +191,7 @@ namespace PactNet.Tests
         [Fact]
         public void Build_WhenCalledWithoutConsumerNameSet_ThrowsInvalidOperationException()
         {
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, providerName) => Substitute.For<IMockProviderService>());
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, rewriteLocalhost, providerName) => Substitute.For<IMockProviderService>());
             pactBuilder.MockService(1234);
             pactBuilder
                 .HasPactWith("Event API");
@@ -202,7 +202,7 @@ namespace PactNet.Tests
         [Fact]
         public void Build_WhenCalledWithoutProviderNameSet_ThrowsInvalidOperationException()
         {
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, providerName) => Substitute.For<IMockProviderService>());
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, rewriteLocalhost, providerName) => Substitute.For<IMockProviderService>());
             pactBuilder.MockService(1234);
             pactBuilder
                 .ServiceConsumer("Event Client");
@@ -217,7 +217,7 @@ namespace PactNet.Tests
             const string providerName = "Event API";
             var mockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, ssl, provider) => mockProviderService);
+            IPactBuilder pactBuilder = new PactBuilder((port, ssl, rewriteLocalhost, provider) => mockProviderService);
             pactBuilder.MockService(1234);
             pactBuilder
                 .ServiceConsumer(consumerName)
@@ -233,7 +233,7 @@ namespace PactNet.Tests
         {
             var mockMockProviderService = Substitute.For<IMockProviderService>();
 
-            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, providerName) => mockMockProviderService)
+            IPactBuilder pactBuilder = new PactBuilder((port, enableSsl, rewriteLocalhost, providerName) => mockMockProviderService)
                 .ServiceConsumer("Event Client")
                 .HasPactWith("Event API");
 

--- a/PactNet/IPactBuilder.cs
+++ b/PactNet/IPactBuilder.cs
@@ -8,8 +8,7 @@ namespace PactNet
         IPactBuilder ServiceConsumer(string consumerName);
         IPactBuilder HasPactWith(string providerName);
         IMockProviderService MockService(int port, bool enableSsl = false);
-        IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false);
-        IMockProviderService MockService(int port, bool rewriteLocalhost, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false);
+        IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false, bool bindOnAllAdapters = false);        
         void Build();
     }
 }

--- a/PactNet/IPactBuilder.cs
+++ b/PactNet/IPactBuilder.cs
@@ -9,6 +9,7 @@ namespace PactNet
         IPactBuilder HasPactWith(string providerName);
         IMockProviderService MockService(int port, bool enableSsl = false);
         IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false);
+        IMockProviderService MockService(int port, bool rewriteLocalhost, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false);
         void Build();
     }
 }

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -41,7 +41,7 @@ namespace PactNet.Mocks.MockHttpService
             _httpMethodMapper = httpMethodMapper;
         }
 
-        public MockProviderService(int port, bool enableSsl, bool bindOnAllAdapters, string providerName, PactConfig config)
+        public MockProviderService(int port, bool enableSsl, string providerName, PactConfig config, bool bindOnAllAdapters)
             : this(
             baseUri =>
             {

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using Newtonsoft.Json;
 using PactNet.Configuration.Json;
+using PactNet.Mocks.MockHttpService.Configuration;
 using PactNet.Mocks.MockHttpService.Mappers;
 using PactNet.Mocks.MockHttpService.Models;
 using PactNet.Mocks.MockHttpService.Nancy;
@@ -40,9 +41,13 @@ namespace PactNet.Mocks.MockHttpService
             _httpMethodMapper = httpMethodMapper;
         }
 
-        public MockProviderService(int port, bool enableSsl, string providerName, PactConfig config)
+        public MockProviderService(int port, bool enableSsl, bool rewriteLocalhost, string providerName, PactConfig config)
             : this(
-            baseUri => new NancyHttpHost(baseUri, providerName, config), 
+            baseUri =>
+            {
+                NancyConfig.HostConfiguration.RewriteLocalhost = rewriteLocalhost;
+                return new NancyHttpHost(baseUri, providerName, config);
+            }, 
             port,
             enableSsl,
             baseUri => new HttpClient { BaseAddress = new Uri(baseUri) },

--- a/PactNet/Mocks/MockHttpService/MockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderService.cs
@@ -41,11 +41,11 @@ namespace PactNet.Mocks.MockHttpService
             _httpMethodMapper = httpMethodMapper;
         }
 
-        public MockProviderService(int port, bool enableSsl, bool rewriteLocalhost, string providerName, PactConfig config)
+        public MockProviderService(int port, bool enableSsl, bool bindOnAllAdapters, string providerName, PactConfig config)
             : this(
             baseUri =>
             {
-                NancyConfig.HostConfiguration.RewriteLocalhost = rewriteLocalhost;
+                NancyConfig.HostConfiguration.RewriteLocalhost = bindOnAllAdapters;
                 return new NancyHttpHost(baseUri, providerName, config);
             }, 
             port,

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -11,10 +11,10 @@ namespace PactNet
     {
         public string ConsumerName { get; private set; }
         public string ProviderName { get; private set; }
-        private readonly Func<int, bool, bool, string, IMockProviderService> _mockProviderServiceFactory;
+        private readonly Func<int, bool, string, bool, IMockProviderService> _mockProviderServiceFactory;
         private IMockProviderService _mockProviderService;
 
-        internal PactBuilder(Func<int, bool,bool, string, IMockProviderService> mockProviderServiceFactory)
+        internal PactBuilder(Func<int, bool, string, bool, IMockProviderService> mockProviderServiceFactory)
         {
             _mockProviderServiceFactory = mockProviderServiceFactory;
         }
@@ -25,7 +25,7 @@ namespace PactNet
         }
 
         public PactBuilder(PactConfig config)
-            : this((port, enableSsl, bindOnAllAdapters, providerName) => new MockProviderService(port, enableSsl, bindOnAllAdapters, providerName, config))
+            : this((port, enableSsl, providerName, bindOnAllAdapters) => new MockProviderService(port, enableSsl, providerName, config, bindOnAllAdapters))
         {
         }
 
@@ -71,7 +71,7 @@ namespace PactNet
                 JsonConfig.ApiSerializerSettings = jsonSerializerSettings;
             }
 
-            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, bindOnAllAdapters, ProviderName);
+            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, ProviderName, bindOnAllAdapters);
 
             _mockProviderService.Start();
 

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -11,10 +11,10 @@ namespace PactNet
     {
         public string ConsumerName { get; private set; }
         public string ProviderName { get; private set; }
-        private readonly Func<int, bool, string, IMockProviderService> _mockProviderServiceFactory;
+        private readonly Func<int, bool, bool, string, IMockProviderService> _mockProviderServiceFactory;
         private IMockProviderService _mockProviderService;
 
-        internal PactBuilder(Func<int, bool, string, IMockProviderService> mockProviderServiceFactory)
+        internal PactBuilder(Func<int, bool,bool, string, IMockProviderService> mockProviderServiceFactory)
         {
             _mockProviderServiceFactory = mockProviderServiceFactory;
         }
@@ -25,7 +25,7 @@ namespace PactNet
         }
 
         public PactBuilder(PactConfig config)
-            : this((port, enableSsl, providerName) => new MockProviderService(port, enableSsl, providerName, config))
+            : this((port, enableSsl, rewriteLocalhost, providerName) => new MockProviderService(port, enableSsl, rewriteLocalhost, providerName, config))
         {
         }
 
@@ -55,10 +55,16 @@ namespace PactNet
 
         public IMockProviderService MockService(int port, bool enableSsl = false)
         {
-            return MockService(port, jsonSerializerSettings: null, enableSsl: enableSsl);
+            return MockService(port, jsonSerializerSettings: null, rewriteLocalhost: true, enableSsl: enableSsl);
         }
+   
 
         public IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false)
+        {
+            return MockService(port, jsonSerializerSettings: jsonSerializerSettings, rewriteLocalhost: true, enableSsl: enableSsl);
+        }
+
+        public IMockProviderService MockService(int port, bool rewriteLocalhost, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false)
         {
             if (_mockProviderService != null)
             {
@@ -70,7 +76,7 @@ namespace PactNet
                 JsonConfig.ApiSerializerSettings = jsonSerializerSettings;
             }
 
-            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, ProviderName);
+            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, rewriteLocalhost, ProviderName);
 
             _mockProviderService.Start();
 

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -25,7 +25,7 @@ namespace PactNet
         }
 
         public PactBuilder(PactConfig config)
-            : this((port, enableSsl, rewriteLocalhost, providerName) => new MockProviderService(port, enableSsl, rewriteLocalhost, providerName, config))
+            : this((port, enableSsl, bindOnAllAdapters, providerName) => new MockProviderService(port, enableSsl, bindOnAllAdapters, providerName, config))
         {
         }
 
@@ -55,16 +55,11 @@ namespace PactNet
 
         public IMockProviderService MockService(int port, bool enableSsl = false)
         {
-            return MockService(port, jsonSerializerSettings: null, rewriteLocalhost: true, enableSsl: enableSsl);
+            return MockService(port, jsonSerializerSettings: null, enableSsl: enableSsl, bindOnAllAdapters: false);
         }
-   
+    
 
-        public IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false)
-        {
-            return MockService(port, jsonSerializerSettings: jsonSerializerSettings, rewriteLocalhost: true, enableSsl: enableSsl);
-        }
-
-        public IMockProviderService MockService(int port, bool rewriteLocalhost, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false)
+        public IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false, bool bindOnAllAdapters = false)
         {
             if (_mockProviderService != null)
             {
@@ -76,7 +71,7 @@ namespace PactNet
                 JsonConfig.ApiSerializerSettings = jsonSerializerSettings;
             }
 
-            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, rewriteLocalhost, ProviderName);
+            _mockProviderService = _mockProviderServiceFactory(port, enableSsl, bindOnAllAdapters, ProviderName);
 
             _mockProviderService.Start();
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ public class ConsumerMyApiPact : IDisposable
 		MockProviderService = PactBuilder.MockService(MockServerPort, true); //By passing true as the second param, you can enabled SSL. This will however require a valid SSL certificate installed and bound with netsh (netsh http add sslcert ipport=0.0.0.0:port certhash=thumbprint appid={app-guid}) on the machine running the test. See https://groups.google.com/forum/#!topic/nancy-web-framework/t75dKyfgzpg
 		//or
 		MockProviderService = PactBuilder.MockService(MockServerPort, new JsonSerializerSettings()); //You can also change the default Json serialization settings using this overload
+		//or
+		MockProviderService = PactBuilder.MockService(MockServerPort, false, new JsonSerializerSettings()); //By passing false as the rewriteLocalhost parameter, the http mock server will only be bound to "localhost", and will not require admin privileges in order to run
 	}
 
 	public void Dispose()

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ public class ConsumerMyApiPact : IDisposable
 		//or
 		MockProviderService = PactBuilder.MockService(MockServerPort, new JsonSerializerSettings()); //You can also change the default Json serialization settings using this overload
 		//or
-		MockProviderService = PactBuilder.MockService(MockServerPort, false, new JsonSerializerSettings()); //By passing false as the rewriteLocalhost parameter, the http mock server will only be bound to "localhost", and will not require admin privileges in order to run
+		MockProviderService = PactBuilder.MockService(MockServerPort, new JsonSerializerSettings(), bindOnAllAdapters:true); //By passing true as the bindOnAllAdapters parameter the http mock server will be able to accept external network requests, but will require admin privileges in order to run
 	}
 
 	public void Dispose()


### PR DESCRIPTION
…o that pact.net can be run without admin privileges

By default nancy runs something like **netsh http add urlacl url=http://+:8799** in order to bind to all ip addresses and not just localhost. The problem with this is that it requires admin privileges to run and makes automation on build servers etc a lot harder.

Nancy has a RewriteLocalhost setting that can disable this, which means only calls to "localhost" will work, but won't require admin privileges to run. 
https://github.com/NancyFx/Nancy/wiki/Self-Hosting-Nancy#host-configuration
