### PR TITLE
async calls to HTTP clients 

### DIFF
--- a/PactNet.Tests/IntegrationTests/FailureIntegrationTestCollection.cs
+++ b/PactNet.Tests/IntegrationTests/FailureIntegrationTestCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace PactNet.Tests.IntegrationTests
+{
+    [CollectionDefinition("Failure integration test collection")]
+    public class FailureIntegrationTestCollection : ICollectionFixture<FailureIntegrationTestsMyApiPact>
+    {
+    }
+}

--- a/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/FailureIntegrationTestsMyApiPact.cs
@@ -12,7 +12,7 @@ namespace PactNet.Tests.IntegrationTests
         public IMockProviderService MockProviderService { get; private set; }
 
         public int MockServerPort { get { return 4321; } }
-        public string MockProviderServiceBaseUri { get { return String.Format("http://localhost:{0}", MockServerPort); } }
+        public string MockProviderServiceBaseUri { get { return $"http://localhost:{MockServerPort}"; } }
 
         public FailureIntegrationTestsMyApiPact()
         {

--- a/PactNet.Tests/IntegrationTests/IntegrationTestCollection.cs
+++ b/PactNet.Tests/IntegrationTests/IntegrationTestCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace PactNet.Tests.IntegrationTests
+{
+    [CollectionDefinition("Integration test collection")]
+    public class IntegrationTestCollection : ICollectionFixture<IntegrationTestsMyApiPact>
+    {
+    }
+}

--- a/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
+++ b/PactNet.Tests/IntegrationTests/IntegrationTestsMyApiPact.cs
@@ -12,7 +12,7 @@ namespace PactNet.Tests.IntegrationTests
         public IMockProviderService MockProviderService { get; private set; }
 
         public int MockServerPort { get { return 4321; } }
-        public string MockProviderServiceBaseUri { get { return String.Format("http://localhost:{0}", MockServerPort); } }
+        public string MockProviderServiceBaseUri { get { return $"http://localhost:{MockServerPort}"; } }
 
         public IntegrationTestsMyApiPact()
         {

--- a/PactNet.Tests/IntegrationTests/PactBuilderFailureIntegrationTests.cs
+++ b/PactNet.Tests/IntegrationTests/PactBuilderFailureIntegrationTests.cs
@@ -2,18 +2,20 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService;
 using PactNet.Mocks.MockHttpService.Models;
 using Xunit;
 
 namespace PactNet.Tests.IntegrationTests
 {
-    public class PactBuilderFailureIntegrationTests : IUseFixture<FailureIntegrationTestsMyApiPact>
+    [Collection("Failure integration test collection")]
+    public class PactBuilderFailureIntegrationTests
     {
         private IMockProviderService _mockProviderService;
         private string _mockProviderServiceBaseUri;
 
-        public void SetFixture(FailureIntegrationTestsMyApiPact data)
+        public PactBuilderFailureIntegrationTests(FailureIntegrationTestsMyApiPact data)
         {
             _mockProviderService = data.MockProviderService;
             _mockProviderServiceBaseUri = data.MockProviderServiceBaseUri;
@@ -21,7 +23,7 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         [Fact]
-        public void WhenRegisteringTheSameInteractionTwiceInATest_ThenPactFailureExceptionIsThrown()
+        public async Task WhenRegisteringTheSameInteractionTwiceInATest_ThenPactFailureExceptionIsThrown()
         {
             var description = "A POST request to create a new thing";
             var request = new ProviderServiceRequest
@@ -44,7 +46,7 @@ namespace PactNet.Tests.IntegrationTests
                 Status = 201
             };
 
-            _mockProviderService
+            await _mockProviderService
                 .UponReceiving(description)
                 .With(request)
                 .WillRespondWith(response);
@@ -52,8 +54,8 @@ namespace PactNet.Tests.IntegrationTests
             _mockProviderService
                 .UponReceiving(description)
                 .With(request);
-                
-            Assert.Throws<PactFailureException>(() => _mockProviderService.WillRespondWith(response));
+
+            await Assert.ThrowsAsync<PactFailureException>(async () => await _mockProviderService.WillRespondWith(response));
         }
 
         [Fact]
@@ -84,9 +86,9 @@ namespace PactNet.Tests.IntegrationTests
         }
 
         [Fact]
-        public void WhenRegisteringAnInteractionThatIsSentMultipleTimes_ThenPactFailureExceptionIsThrown()
+        public async Task WhenRegisteringAnInteractionThatIsSentMultipleTimes_ThenPactFailureExceptionIsThrown()
         {
-            _mockProviderService
+            await _mockProviderService
                 .UponReceiving("A GET request to retrieve a thing")
                 .With(new ProviderServiceRequest
                 {
@@ -98,26 +100,27 @@ namespace PactNet.Tests.IntegrationTests
                     Status = 200
                 });
 
-            var httpClient = new HttpClient {BaseAddress = new Uri(_mockProviderServiceBaseUri)};
+            var httpClient = new HttpClient { BaseAddress = new Uri(_mockProviderServiceBaseUri) };
 
             var request1 = new HttpRequestMessage(HttpMethod.Get, "/things/1234");
             var request2 = new HttpRequestMessage(HttpMethod.Get, "/things/1234");
 
-            var response1 = httpClient.SendAsync(request1).Result;
-            var response2 = httpClient.SendAsync(request2).Result;
+            var response1 = await httpClient.SendAsync(request1);
+            var response2 = await httpClient.SendAsync(request2);
 
             if (response1.StatusCode != HttpStatusCode.OK || response2.StatusCode != HttpStatusCode.OK)
             {
-                throw new Exception(String.Format("Wrong status code '{0} and {1}' was returned", response1.StatusCode, response2.StatusCode));
+                throw new Exception(
+                    $"Wrong status code '{response1.StatusCode} and {response2.StatusCode}' was returned");
             }
 
             Assert.Throws<PactFailureException>(() => _mockProviderService.VerifyInteractions());
         }
 
         [Fact]
-        public void WhenRegisteringAnInteractionWhereTheRequestDoesNotExactlyMatchTheActualRequest_ThenStatusCodeReturnedIs500AndPactFailureExceptionIsThrown()
+        public async Task WhenRegisteringAnInteractionWhereTheRequestDoesNotExactlyMatchTheActualRequest_ThenStatusCodeReturnedIs500AndPactFailureExceptionIsThrown()
         {
-            _mockProviderService
+            await _mockProviderService
                 .UponReceiving("A GET request to retrieve things by type")
                 .With(new ProviderServiceRequest
                 {
@@ -138,11 +141,11 @@ namespace PactNet.Tests.IntegrationTests
 
             var request = new HttpRequestMessage(HttpMethod.Get, "/things?type=awesome");
 
-            var response = httpClient.SendAsync(request).Result;
+            var response = await httpClient.SendAsync(request);
 
             if (response.StatusCode != HttpStatusCode.InternalServerError)
             {
-                throw new Exception(String.Format("Wrong status code '{0}' was returned", response.StatusCode));
+                throw new Exception($"Wrong status code '{response.StatusCode}' was returned");
             }
 
             Assert.Throws<PactFailureException>(() => _mockProviderService.VerifyInteractions());

--- a/PactNet.Tests/IntegrationTests/PactBuilderIntegrationTests.cs
+++ b/PactNet.Tests/IntegrationTests/PactBuilderIntegrationTests.cs
@@ -3,12 +3,13 @@ using Xunit;
 
 namespace PactNet.Tests.IntegrationTests
 {
-    public class PactBuilderIntegrationTests : IUseFixture<IntegrationTestsMyApiPact>
+    [Collection("Integration test collection")]
+    public class PactBuilderIntegrationTests
     {
         private IMockProviderService _mockProviderService;
         private string _mockProviderServiceBaseUri;
 
-        public void SetFixture(IntegrationTestsMyApiPact data)
+        public PactBuilderIntegrationTests(IntegrationTestsMyApiPact data)
         {
             _mockProviderService = data.MockProviderService;
             _mockProviderServiceBaseUri = data.MockProviderServiceBaseUri;

--- a/PactNet.Tests/IntegrationTests/Specification/MockHttpServiceSpecificationTests.cs
+++ b/PactNet.Tests/IntegrationTests/Specification/MockHttpServiceSpecificationTests.cs
@@ -52,7 +52,8 @@ namespace PactNet.Tests.IntegrationTests.Specification
 
             if (!Directory.Exists(pathToTestCases))
             {
-                throw new InvalidOperationException(String.Format("Specification tests not found in path '{0}'. Please ensure pact-specification git submodule has been pulled (git submodule update --init).", pathToTestCases));
+                throw new InvalidOperationException(
+                    $"Specification tests not found in path '{pathToTestCases}'. Please ensure pact-specification git submodule has been pulled (git submodule update --init).");
             }
 
             foreach (var testCaseSubDirectory in Directory.EnumerateDirectories(pathToTestCases))
@@ -70,7 +71,7 @@ namespace PactNet.Tests.IntegrationTests.Specification
                     }
                     catch (SubstituteException)
                     {
-                        failedTestCases.Add(String.Format("[Failed] {0}", testCaseFileName));
+                        failedTestCases.Add($"[Failed] {testCaseFileName}");
                     }
                 }
             }

--- a/PactNet.Tests/Mocks/MockHttpService/Comparers/HttpQueryStringComparerTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Comparers/HttpQueryStringComparerTests.cs
@@ -17,7 +17,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Comparers
         {
             var comparer = GetSubject();
 
-            var result = comparer.Compare(null, String.Empty);
+            var result = comparer.Compare(null, string.Empty);
 
             Assert.False(result.HasFailure, "There should not be any errors");
         }

--- a/PactNet.Tests/Mocks/MockHttpService/Mappers/HttpContentMapperTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Mappers/HttpContentMapperTests.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService.Mappers;
 using PactNet.Mocks.MockHttpService.Models;
 using Xunit;
@@ -26,18 +27,18 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
         }
 
         [Fact]
-        public void Convert_WithEmptyContent_ReturnsNull()
+        public async Task Convert_WithEmptyContent_ReturnsNull()
         {
-            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" });
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" });
             var mapper = GetSubject();
 
             var result = mapper.Convert(httpBodyContent);
 
-            Assert.Empty(result.ReadAsStringAsync().Result);
+            Assert.Empty(await result.ReadAsStringAsync());
         }
 
         [Fact]
-        public void Convert_WithContentTypeContainingParameter_ReturnsContentWithContentTypeHeader()
+        public async Task Convert_WithContentTypeContainingParameter_ReturnsContentWithContentTypeHeader()
         {
             const string contentType = "text/plain";
             const string content = "test";
@@ -53,7 +54,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
             Assert.Equal(contentType, result.Headers.ContentType.MediaType);
             Assert.Contains(versionParameter, result.Headers.ContentType.Parameters);
             Assert.Equal("utf-8", result.Headers.ContentType.CharSet);
-            Assert.Equal(content, result.ReadAsStringAsync().Result);
+            Assert.Equal(content, await result.ReadAsStringAsync());
         }
     }
 }

--- a/PactNet.Tests/Mocks/MockHttpService/Mappers/HttpRequestMessageMapperTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Mappers/HttpRequestMessageMapperTests.cs
@@ -8,6 +8,7 @@ using NSubstitute;
 using PactNet.Mocks.MockHttpService.Mappers;
 using PactNet.Mocks.MockHttpService.Models;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace PactNet.Tests.Mocks.MockHttpService.Mappers
 {
@@ -70,7 +71,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
             var mapper = GetSubject();
 
             _mockHttpMethodMapper.Convert(HttpVerb.Post).Returns(HttpMethod.Post);
-            _mockHttpBodyContentMapper.Convert(Arg.Any<object>(), request.Headers).Returns(new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" }));
+            _mockHttpBodyContentMapper.Convert(Arg.Any<object>(), request.Headers).Returns(new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" }));
 
             var result = mapper.Convert(request);
 
@@ -92,7 +93,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
                 },
                 Body = new { }
             };
-            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = "utf-8" });
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = "utf-8" });
 
             var mapper = GetSubject();
 
@@ -119,7 +120,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
                 },
                 Body = new { }
             };
-            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = "utf-8" });
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = "utf-8" });
 
             var mapper = GetSubject();
 
@@ -148,7 +149,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
                 },
                 Body = new { }
             };
-            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = encodingString });
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = encodingString });
 
             var mapper = GetSubject();
 
@@ -178,7 +179,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
                 },
                 Body = new { }
             };
-            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = encodingString });
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = encodingString });
 
             var mapper = GetSubject();
 
@@ -207,7 +208,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
                 },
                 Body = new { }
             };
-            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = "utf-8" });
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue(contentTypeString) { CharSet = "utf-8" });
 
             var mapper = GetSubject();
 
@@ -352,7 +353,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
         }
 
         [Fact]
-        public void Convert_WithTheWorks_CorrectlyMappedHttpRequestMessageIsReturned()
+        public async Task Convert_WithTheWorks_CorrectlyMappedHttpRequestMessageIsReturned()
         {
             const string encodingString = "utf-8";
             const string contentTypeString = "application/json";
@@ -383,7 +384,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
             _mockHttpBodyContentMapper.Convert(Arg.Any<object>(), request.Headers).Returns(httpBodyContent);
 
             var result = mapper.Convert(request);
-            var requestContent = result.Content.ReadAsStringAsync().Result;
+            var requestContent = await result.Content.ReadAsStringAsync();
 
             var contentTypeHeader = result.Content.Headers.First(x => x.Key.Equals("Content-Type"));
             var customHeader = result.Headers.First(x => x.Key.Equals("X-Custom"));

--- a/PactNet.Tests/Mocks/MockHttpService/Mappers/ProviderServiceRequestMapperTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Mappers/ProviderServiceRequestMapperTests.cs
@@ -188,7 +188,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
         {
             RequestStream requestStream = null;
 
-            if (!String.IsNullOrEmpty(content))
+            if (!string.IsNullOrEmpty(content))
             {
                 var contentBytes = Encoding.UTF8.GetBytes(content);
                 var stream = new MemoryStream(contentBytes);

--- a/PactNet.Tests/Mocks/MockHttpService/Mappers/ProviderServiceResponseMapperTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Mappers/ProviderServiceResponseMapperTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 using NSubstitute;
 using PactNet.Mocks.MockHttpService.Mappers;
 using PactNet.Mocks.MockHttpService.Models;
@@ -23,7 +24,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
         }
 
         [Fact]
-        public void Convert_WithStatusCode_CorrectlyMapsStatusCode()
+        public async Task Convert_WithStatusCode_CorrectlyMapsStatusCode()
         {
             var message = new HttpResponseMessage { StatusCode = HttpStatusCode.Accepted };
 
@@ -31,13 +32,13 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
 
             IProviderServiceResponseMapper mapper = new ProviderServiceResponseMapper(mockHttpBodyContentMapper);
 
-            var result = mapper.Convert(message);
+            var result = await mapper.Convert(message);
 
             Assert.Equal(202, result.Status);
         }
 
         [Fact]
-        public void Convert_WithResponseHeaders_CorrectlyMapsHeaders()
+        public async Task Convert_WithResponseHeaders_CorrectlyMapsHeaders()
         {
             const string headerValue = "Customer Header Value";
             var message = new HttpResponseMessage
@@ -50,15 +51,15 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
 
             IProviderServiceResponseMapper mapper = new ProviderServiceResponseMapper(mockHttpBodyContentMapper);
 
-            var result = mapper.Convert(message);
+            var result = await mapper.Convert(message);
 
             Assert.Equal(headerValue, result.Headers["X-Custom"]);
         }
 
         [Fact]
-        public void Convert_WithResponseContentHeaders_CorrectlyMapsHeaders()
+        public async Task Convert_WithResponseContentHeaders_CorrectlyMapsHeaders()
         {
-            var stringContent = new StringContent(String.Empty, Encoding.UTF8, "text/plain");
+            var stringContent = new StringContent(string.Empty, Encoding.UTF8, "text/plain");
 
             var message = new HttpResponseMessage
             {
@@ -67,19 +68,19 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
             };
 
             var mockHttpBodyContentMapper = Substitute.For<IHttpBodyContentMapper>();
-            mockHttpBodyContentMapper.Convert(Arg.Any<byte[]>(), Arg.Any<IDictionary<string, string>>()).Returns(new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" }));
+            mockHttpBodyContentMapper.Convert(Arg.Any<byte[]>(), Arg.Any<IDictionary<string, string>>()).Returns(new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" }));
 
             IProviderServiceResponseMapper mapper = new ProviderServiceResponseMapper(mockHttpBodyContentMapper);
 
-            var result = mapper.Convert(message);
+            var result = await mapper.Convert(message);
 
             Assert.Equal("text/plain; charset=utf-8", result.Headers["Content-Type"]);
         }
 
         [Fact]
-        public void Convert_WithResponseAndResponseContentHeaders_CorrectlyMapsHeaders()
+        public async Task Convert_WithResponseAndResponseContentHeaders_CorrectlyMapsHeaders()
         {
-            var stringContent = new StringContent(String.Empty, Encoding.UTF8, "text/plain");
+            var stringContent = new StringContent(string.Empty, Encoding.UTF8, "text/plain");
             const string headerValue = "Customer Header Value";
 
             var message = new HttpResponseMessage
@@ -90,18 +91,18 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
             message.Headers.Add("X-Custom", headerValue);
 
             var mockHttpBodyContentMapper = Substitute.For<IHttpBodyContentMapper>();
-            mockHttpBodyContentMapper.Convert(Arg.Any<byte[]>(), Arg.Any<IDictionary<string, string>>()).Returns(new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" }));
+            mockHttpBodyContentMapper.Convert(Arg.Any<byte[]>(), Arg.Any<IDictionary<string, string>>()).Returns(new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" }));
 
             IProviderServiceResponseMapper mapper = new ProviderServiceResponseMapper(mockHttpBodyContentMapper);
 
-            var result = mapper.Convert(message);
+            var result = await mapper.Convert(message);
 
             Assert.Equal(headerValue, result.Headers["X-Custom"]);
             Assert.Equal("text/plain; charset=utf-8", result.Headers["Content-Type"]);
         }
 
         [Fact]
-        public void Convert_WithPlainTextContent_CallsConvertOnHttpBodyContentMapperAndCorrectlyMapsBody()
+        public async Task Convert_WithPlainTextContent_CallsConvertOnHttpBodyContentMapperAndCorrectlyMapsBody()
         {
             const string content = "some plaintext content";
 
@@ -118,14 +119,14 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
 
             IProviderServiceResponseMapper mapper = new ProviderServiceResponseMapper(mockHttpBodyContentMapper);
 
-            var result = mapper.Convert(message);
+            var result = await mapper.Convert(message);
 
             Assert.Equal(content, result.Body);
             mockHttpBodyContentMapper.Received(1).Convert(Arg.Is<byte[]>(x => CompareBytes(Encoding.UTF8.GetBytes(content), x)), Arg.Any<Dictionary<string, string>>());
         }
 
         [Fact]
-        public void Convert_WithJsonContent_CallsConvertOnHttpBodyContentMapperAndCorrectlyMapsBody()
+        public async Task Convert_WithJsonContent_CallsConvertOnHttpBodyContentMapperAndCorrectlyMapsBody()
         {
             var body = new
             {
@@ -147,7 +148,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Mappers
 
             IProviderServiceResponseMapper mapper = new ProviderServiceResponseMapper(mockHttpBodyContentMapper);
 
-            var result = mapper.Convert(message);
+            var result = await mapper.Convert(message);
 
             Assert.Equal(body.Test, (string)result.Body.Test);
             Assert.Equal(body.test2, (int)result.Body.test2);

--- a/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/MockProviderServiceTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NSubstitute;
 using PactNet.Configuration.Json;
@@ -41,7 +42,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         public void Ctor_WhenCalledWithPort_SetsBaseUri()
         {
             const int port = 999;
-            var expectedBaseUri = String.Format("http://localhost:{0}", port);
+            var expectedBaseUri = $"http://localhost:{port}";
             var mockService = GetSubject(port);
 
             Assert.Equal(expectedBaseUri, ((MockProviderService)mockService).BaseUri);
@@ -94,7 +95,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         {
             var mockService = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => mockService.Given(String.Empty));
+            Assert.Throws<ArgumentException>(() => mockService.Given(string.Empty));
         }
 
         [Fact]
@@ -126,7 +127,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         {
             var mockService = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => mockService.UponReceiving(String.Empty));
+            Assert.Throws<ArgumentException>(() => mockService.UponReceiving(string.Empty));
         }
 
         [Fact]
@@ -211,37 +212,37 @@ namespace PactNet.Tests.Mocks.MockHttpService
         }
 
         [Fact]
-        public void WillRespondWith_WithNullResponse_ThrowsArgumentException()
+        public async Task WillRespondWith_WithNullResponse_ThrowsArgumentException()
         {
             var mockService = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => mockService.WillRespondWith(null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await mockService.WillRespondWith(null));
         }
 
         [Fact]
-        public void WillRespondWith_WithNullDescription_ThrowsInvalidOperationException()
+        public async Task WillRespondWith_WithNullDescription_ThrowsInvalidOperationException()
         {
             var mockService = GetSubject();
 
             mockService
                 .With(new ProviderServiceRequest { Method = HttpVerb.Get });
 
-            Assert.Throws<InvalidOperationException>(() => mockService.WillRespondWith(new ProviderServiceResponse { Status = (int)HttpStatusCode.OK }));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await mockService.WillRespondWith(new ProviderServiceResponse { Status = (int)HttpStatusCode.OK }));
         }
 
         [Fact]
-        public void WillRespondWith_WithNullRequest_ThrowsInvalidOperationException()
+        public async Task WillRespondWith_WithNullRequest_ThrowsInvalidOperationException()
         {
             var mockService = GetSubject();
 
             mockService
                 .UponReceiving("My description");
 
-            Assert.Throws<InvalidOperationException>(() => mockService.WillRespondWith(new ProviderServiceResponse { Status = (int)HttpStatusCode.OK }));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await mockService.WillRespondWith(new ProviderServiceResponse { Status = (int)HttpStatusCode.OK }));
         }
 
         [Fact]
-        public void WillRespondWith_WithResponseThatContainsABodyAndNoContentType_ThrowsArgumentException()
+        public async Task WillRespondWith_WithResponseThatContainsABodyAndNoContentType_ThrowsArgumentException()
         {
             var providerState = "My provider state";
             var description = "My description";
@@ -262,11 +263,11 @@ namespace PactNet.Tests.Mocks.MockHttpService
                 .UponReceiving(description)
                 .With(request);
 
-            Assert.Throws<ArgumentException>(() => mockService.WillRespondWith(response));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await mockService.WillRespondWith(response));
         }
 
         [Fact]
-        public void WillRespondWith_WithResponseThatDoesNotHaveAResponseStatusSet_ThrowsArgumentException()
+        public async Task WillRespondWith_WithResponseThatDoesNotHaveAResponseStatusSet_ThrowsArgumentException()
         {
             var providerState = "My provider state";
             var description = "My description";
@@ -280,11 +281,11 @@ namespace PactNet.Tests.Mocks.MockHttpService
                 .UponReceiving(description)
                 .With(request);
 
-            Assert.Throws<ArgumentException>(() => mockService.WillRespondWith(response));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await mockService.WillRespondWith(response));
         }
 
         [Fact]
-        public void WillRespondWith_WhenHostIsNull_ThrowsInvalidOperationException()
+        public async Task WillRespondWith_WhenHostIsNull_ThrowsInvalidOperationException()
         {
             var providerState = "My provider state";
             var description = "My description";
@@ -300,7 +301,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
 
             mockService.Stop();
 
-            Assert.Throws<InvalidOperationException>(() => mockService.WillRespondWith(response));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await mockService.WillRespondWith(response));
             Assert.Equal(0, _fakeHttpMessageHandler.RequestsReceived.Count());
         }
 
@@ -377,7 +378,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
         }
 
         [Fact]
-        public void WillRespondWith_WhenResponseFromHostIsNotOk_ThrowsPactFailureException()
+        public async Task WillRespondWith_WhenResponseFromHostIsNotOk_ThrowsPactFailureException()
         {
             var providerState = "My provider state";
             var description = "My description";
@@ -395,7 +396,7 @@ namespace PactNet.Tests.Mocks.MockHttpService
 
             mockService.Start();
 
-            Assert.Throws<PactFailureException>(() => mockService.WillRespondWith(response));
+            await Assert.ThrowsAsync<PactFailureException>(async () => await mockService.WillRespondWith(response));
         }
 
         [Fact]

--- a/PactNet.Tests/Mocks/MockHttpService/Models/HttpBodyContentTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Models/HttpBodyContentTests.cs
@@ -220,7 +220,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Models
         [Fact]
         public void Ctor2_WithEmptyContent_ReturnsEmptyUtf8ByteArray()
         {
-            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(String.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" });
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(string.Empty), contentType: new MediaTypeHeaderValue("text/plain") { CharSet = "utf-8" });
 
             Assert.Empty(httpBodyContent.ContentBytes);
         }

--- a/PactNet.Tests/Mocks/MockHttpService/Nancy/MockProviderAdminRequestHandlerTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Nancy/MockProviderAdminRequestHandlerTests.cs
@@ -62,7 +62,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Nancy
 
             handler.Handle(context);
 
-            _mockLog.Received(1).Log(LogLevel.Info, Arg.Any<Func<string>>(), null, Arg.Is<object[]>(x => x.Single() == testContext));
+            _mockLog.Received(1).Log(LogLevel.Info, Arg.Any<Func<string>>(), null, Arg.Is<object[]>(x => (string)x.Single() == testContext));
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Nancy
 
             handler.Handle(context);
 
-            _mockLog.Received(0).Log(LogLevel.Info, Arg.Any<Func<string>>(), null, Arg.Is<object[]>(x => x.Single() == testContext));
+            _mockLog.Received(0).Log(LogLevel.Info, Arg.Any<Func<string>>(), null, Arg.Is<object[]>(x => (string)x.Single() == testContext));
         }
 
         [Fact]

--- a/PactNet.Tests/Mocks/MockHttpService/Validators/ProviderServiceValidatorTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Validators/ProviderServiceValidatorTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NSubstitute;
 using PactNet.Comparers;
 using PactNet.Mocks.MockHttpService;
@@ -29,15 +30,15 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
         }
 
         [Fact]
-        public void Validate_WithNullPactFile_ThrowsArgumentException()
+        public async Task Validate_WithNullPactFile_ThrowsArgumentException()
         {
             var validator = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => validator.Validate(null, null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await validator.Validate(null, null));
         }
 
         [Fact]
-        public void Validate_WithNullConsumer_ThrowsArgumentException()
+        public async Task Validate_WithNullConsumer_ThrowsArgumentException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -46,11 +47,12 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
 
             var validator = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await validator.Validate(pact, null));
+
         }
 
         [Fact]
-        public void Validate_WithNullConsumerName_ThrowsArgumentException()
+        public async Task Validate_WithNullConsumerName_ThrowsArgumentException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -60,25 +62,27 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
 
             var validator = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await validator.Validate(pact, null));
+
         }
 
         [Fact]
-        public void Validate_WithEmptyConsumerName_ThrowsArgumentException()
+        public async Task Validate_WithEmptyConsumerName_ThrowsArgumentException()
         {
             var pact = new ProviderServicePactFile
             {
-                Consumer = new Pacticipant { Name = String.Empty },
+                Consumer = new Pacticipant { Name = string.Empty },
                 Provider = new Pacticipant { Name = "My Provider" }
             };
 
             var validator = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await validator.Validate(pact, null));
+
         }
 
         [Fact]
-        public void Validate_WithNullProvider_ThrowsArgumentException()
+        public async Task Validate_WithNullProvider_ThrowsArgumentException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -87,11 +91,12 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
 
             var validator = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await validator.Validate(pact, null));
+
         }
 
         [Fact]
-        public void Validate_WithNullProviderName_ThrowsArgumentException()
+        public async Task Validate_WithNullProviderName_ThrowsArgumentException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -101,21 +106,22 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
 
             var validator = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await validator.Validate(pact, null));
+
         }
 
         [Fact]
-        public void Validate_WithEmptyProviderName_ThrowsArgumentException()
+        public async Task Validate_WithEmptyProviderName_ThrowsArgumentException()
         {
             var pact = new ProviderServicePactFile
             {
                 Consumer = new Pacticipant { Name = "My client" },
-                Provider = new Pacticipant { Name = String.Empty },
+                Provider = new Pacticipant { Name = string.Empty },
             };
 
             var validator = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await validator.Validate(pact, null));
         }
 
         [Fact]
@@ -204,7 +210,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
         }
 
         [Fact]
-        public void Validate_WhenProviderServiceResponseComparerThrowsPactFailureException_ThrowsPactFailureException()
+        public async Task Validate_WhenProviderServiceResponseComparerThrowsPactFailureException_ThrowsPactFailureException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -225,7 +231,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
                 .When(x => x.Compare(Arg.Any<ProviderServiceResponse>(), Arg.Any<ProviderServiceResponse>()))
                 .Do(x => { throw new PactFailureException("Expected response cannot be null"); });
 
-            Assert.Throws<PactFailureException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<PactFailureException>(async () => await validator.Validate(pact, null));
         }
 
         [Fact]
@@ -306,7 +312,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
         }
 
         [Fact]
-        public void Validate_WhenProviderServiceResponseComparerThrowsAndProviderStatesTearDownDefined_TearDownActionIsInvoked()
+        public async Task Validate_WhenProviderServiceResponseComparerThrowsAndProviderStatesTearDownDefined_TearDownActionIsInvoked()
         {
             var actionInkoved = false;
             var pact = new ProviderServicePactFile
@@ -329,7 +335,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
                 .When(x => x.Compare(Arg.Any<ProviderServiceResponse>(), Arg.Any<ProviderServiceResponse>()))
                 .Do(x => { throw new PactFailureException("Expected response cannot be null"); });
 
-            Assert.Throws<PactFailureException>(() => validator.Validate(pact, providerStates));
+            await Assert.ThrowsAsync<PactFailureException>(async () => await validator.Validate(pact, providerStates));
 
             Assert.True(actionInkoved, "Provider states pact tearDown action is invoked");
         }
@@ -389,7 +395,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
         }
 
         [Fact]
-        public void Validate_WhenInteractionDefinesAProviderStateAndProviderStateTearDownDefinedAndProviderServiceResponseComparerThrows_TearDownActionIsInvoked()
+        public async Task Validate_WhenInteractionDefinesAProviderStateAndProviderStateTearDownDefinedAndProviderServiceResponseComparerThrows_TearDownActionIsInvoked()
         {
             var actionInkoved = false;
             var pact = new ProviderServicePactFile
@@ -414,13 +420,13 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
                 .When(x => x.Compare(Arg.Any<ProviderServiceResponse>(), Arg.Any<ProviderServiceResponse>()))
                 .Do(x => { throw new PactFailureException("Expected response cannot be null"); });
 
-            Assert.Throws<PactFailureException>(() => validator.Validate(pact, providerStates));
+            await Assert.ThrowsAsync<PactFailureException>(async () => await validator.Validate(pact, providerStates));
 
             Assert.True(actionInkoved, "Provider state tearDown action is invoked");
         }
 
         [Fact]
-        public void Validate_WhenInteractionDefinesAProviderStateButNoProviderStateIsSupplied_ThrowsInvalidOperationException()
+        public async Task Validate_WhenInteractionDefinesAProviderStateButNoProviderStateIsSupplied_ThrowsInvalidOperationException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -439,11 +445,11 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
 
             var validator = GetSubject();
 
-            Assert.Throws<InvalidOperationException>(() => validator.Validate(pact, providerStates));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await validator.Validate(pact, providerStates));
         }
 
         [Fact]
-        public void Validate_WhenInteractionDefinesAProviderStateAndNoProviderStatesAreSupplied_ThrowsInvalidOperationException()
+        public async Task Validate_WhenInteractionDefinesAProviderStateAndNoProviderStatesAreSupplied_ThrowsInvalidOperationException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -461,11 +467,11 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
 
             var validator = GetSubject();
 
-            Assert.Throws<InvalidOperationException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await validator.Validate(pact, null));
         }
 
         [Fact]
-        public void Validate_WhenInteractionDefinesAProviderStateAndProviderStateIsNotFound_ThrowsInvalidOperationException()
+        public async Task Validate_WhenInteractionDefinesAProviderStateAndProviderStateIsNotFound_ThrowsInvalidOperationException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -486,7 +492,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
 
             var validator = GetSubject();
 
-            Assert.Throws<InvalidOperationException>(() => validator.Validate(pact, providerStates));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await validator.Validate(pact, providerStates));
         }
 
         [Fact]
@@ -557,7 +563,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
         }
 
         [Fact]
-        public void Validate_WhenAFailureOccurs_ThrowsPactFailureException()
+        public async Task Validate_WhenAFailureOccurs_ThrowsPactFailureException()
         {
             var pact = new ProviderServicePactFile
             {
@@ -581,7 +587,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Validators
                 .Compare(Arg.Any<ProviderServiceResponse>(), Arg.Any<ProviderServiceResponse>())
                 .Returns(comparisonResult);
 
-            Assert.Throws<PactFailureException>(() => validator.Validate(pact, null));
+            await Assert.ThrowsAsync<PactFailureException>(async () => await validator.Validate(pact, null));
         }
     }
 }

--- a/PactNet.Tests/PactBuilderTests.cs
+++ b/PactNet.Tests/PactBuilderTests.cs
@@ -40,7 +40,7 @@ namespace PactNet.Tests
         {
             var pactBuilder = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactBuilder.ServiceConsumer(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactBuilder.ServiceConsumer(string.Empty));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace PactNet.Tests
         {
             var pactBuilder = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactBuilder.HasPactWith(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactBuilder.HasPactWith(string.Empty));
         }
 
         [Fact]

--- a/PactNet.Tests/PactNet.Tests.csproj
+++ b/PactNet.Tests/PactNet.Tests.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PactNet.Tests</RootNamespace>
     <AssemblyName>PactNet.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -26,6 +26,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,6 +35,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Nancy, Version=0.23.1.0, Culture=neutral, processorArchitecture=MSIL">
@@ -44,53 +46,53 @@
       <HintPath>..\packages\Nancy.Hosting.Self.0.23.1\lib\net40\Nancy.Hosting.Self.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NSubstitute, Version=1.7.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NSubstitute.1.7.2.0\lib\NET40\NSubstitute.dll</HintPath>
+      <HintPath>..\packages\NSubstitute.1.7.2.0\lib\NET45\NSubstitute.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IO">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
-    </Reference>
     <Reference Include="System.IO.Abstractions, Version=1.4.0.86, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.IO.Abstractions.1.4.0.86\lib\net35\System.IO.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.WebRequest, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Comparers\ComparisonResultTests.cs" />
     <Compile Include="Fakes\FakeHttpMessageHandler.cs" />
+    <Compile Include="IntegrationTests\FailureIntegrationTestCollection.cs" />
     <Compile Include="IntegrationTests\FailureIntegrationTestsMyApiPact.cs" />
+    <Compile Include="IntegrationTests\IntegrationTestCollection.cs" />
     <Compile Include="IntegrationTests\IntegrationTestingMockProviderNancyBootstrapper.cs" />
     <Compile Include="IntegrationTests\IntegrationTestsMyApiPact.cs" />
     <Compile Include="IntegrationTests\PactBuilderFailureIntegrationTests.cs" />
@@ -157,11 +159,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -170,6 +167,11 @@
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.0.1\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/PactNet.Tests/PactVerifierTests.cs
+++ b/PactNet.Tests/PactVerifierTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using NSubstitute;
 using PactNet.Mocks.MockHttpService;
 using PactNet.Mocks.MockHttpService.Models;
@@ -31,10 +32,10 @@ namespace PactNet.Tests
             _mockProviderServiceValidator = Substitute.For<IProviderServiceValidator>();
             _fakeHttpMessageHandler = new FakeHttpMessageHandler();
 
-            return new PactVerifier(() => {}, () => {}, _mockFileSystem, (httpRequestSender, reporter, config) =>
+            return new PactVerifier(() => { }, () => { }, _mockFileSystem, (httpRequestSender, reporter, config) =>
             {
                 _providerServiceValidatorFactoryCallInfo = new Tuple<bool, IHttpRequestSender>(true, httpRequestSender);
-                
+
                 return _mockProviderServiceValidator;
             }, new HttpClient(_fakeHttpMessageHandler), null);
         }
@@ -62,7 +63,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => 
+            Assert.Throws<ArgumentException>(() =>
                 pactVerifier
                 .ProviderState(null));
         }
@@ -74,7 +75,7 @@ namespace PactNet.Tests
 
             Assert.Throws<ArgumentException>(() =>
                 pactVerifier
-                .ProviderState(String.Empty));
+                .ProviderState(string.Empty));
         }
 
         [Fact]
@@ -90,7 +91,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.ServiceProvider(String.Empty, new HttpClient()));
+            Assert.Throws<ArgumentException>(() => pactVerifier.ServiceProvider(string.Empty, new HttpClient()));
         }
 
         [Fact]
@@ -164,7 +165,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.ServiceProvider("Event API", (Func<ProviderServiceRequest, ProviderServiceResponse>) null));
+            Assert.Throws<ArgumentException>(() => pactVerifier.ServiceProvider("Event API", (Func<ProviderServiceRequest, ProviderServiceResponse>)null));
         }
 
         [Fact]
@@ -196,7 +197,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.HonoursPactWith(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactVerifier.HonoursPactWith(string.Empty));
         }
 
         [Fact]
@@ -234,7 +235,7 @@ namespace PactNet.Tests
         {
             var pactVerifier = GetSubject();
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.PactUri(String.Empty));
+            Assert.Throws<ArgumentException>(() => pactVerifier.PactUri(string.Empty));
         }
 
         [Fact]
@@ -249,21 +250,21 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        public void Verify_WhenHttpRequestSenderIsNull_ThrowsInvalidOperationException()
+        public async Task Verify_WhenHttpRequestSenderIsNull_ThrowsInvalidOperationException()
         {
             var pactVerifier = GetSubject();
             pactVerifier.PactUri("../../../Consumer.Tests/pacts/my_client-event_api.json");
 
-            Assert.Throws<InvalidOperationException>(() => pactVerifier.Verify());
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await pactVerifier.Verify());
         }
 
         [Fact]
-        public void Verify_WhenPactFileUriIsNull_ThrowsInvalidOperationException()
+        public async Task Verify_WhenPactFileUriIsNull_ThrowsInvalidOperationException()
         {
             var pactVerifier = GetSubject();
             pactVerifier.ServiceProvider("Event API", new HttpClient());
 
-            Assert.Throws<InvalidOperationException>(() => pactVerifier.Verify());
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await pactVerifier.Verify());
         }
 
         [Fact]
@@ -370,7 +371,7 @@ namespace PactNet.Tests
         }
 
         [Fact]
-        public void Verify_WithFileUriAndWhenFileDoesNotExistOnFileSystem_ThrowsInvalidOperationException()
+        public async Task Verify_WithFileUriAndWhenFileDoesNotExistOnFileSystem_ThrowsInvalidOperationException()
         {
             var serviceProvider = "Event API";
             var serviceConsumer = "My client";
@@ -385,13 +386,13 @@ namespace PactNet.Tests
                 .HonoursPactWith(serviceConsumer)
                 .PactUri(pactUri);
 
-            Assert.Throws<InvalidOperationException>(() => pactVerifier.Verify());
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await pactVerifier.Verify());
 
             _mockFileSystem.File.Received(1).ReadAllText(pactUri);
         }
 
         [Fact]
-        public void Verify_WithHttpUriAndNonSuccessfulStatusCodeIsReturned_ThrowsInvalidOperationException()
+        public async Task Verify_WithHttpUriAndNonSuccessfulStatusCodeIsReturned_ThrowsInvalidOperationException()
         {
             var serviceProvider = "Event API";
             var serviceConsumer = "My client";
@@ -406,13 +407,13 @@ namespace PactNet.Tests
                 .HonoursPactWith(serviceConsumer)
                 .PactUri(pactUri);
 
-            Assert.Throws<InvalidOperationException>(() => pactVerifier.Verify());
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await pactVerifier.Verify());
 
             Assert.Equal(HttpMethod.Get, _fakeHttpMessageHandler.RequestsReceived.Single().Method);
         }
 
         [Fact]
-        public void Verify_WhenPactFileWithNoInteractionsExistOnFileSystem_CallsPactProviderValidator()
+        public async Task Verify_WhenPactFileWithNoInteractionsExistOnFileSystem_CallsPactProviderValidator()
         {
             var serviceProvider = "Event API";
             var serviceConsumer = "My client";
@@ -429,11 +430,11 @@ namespace PactNet.Tests
                 .HonoursPactWith(serviceConsumer)
                 .PactUri(pactUri);
 
-            pactVerifier.Verify();
+            await pactVerifier.Verify();
 
             _mockFileSystem.File.Received(1).ReadAllText(pactUri);
 
-            _mockProviderServiceValidator.Received(1).Validate(Arg.Any<ProviderServicePactFile>(), Arg.Any<ProviderStates>());
+            await _mockProviderServiceValidator.Received(1).Validate(Arg.Any<ProviderServicePactFile>(), Arg.Any<ProviderStates>());
         }
 
         [Fact]
@@ -512,7 +513,7 @@ namespace PactNet.Tests
             pactVerifier.Verify(providerState: providerState);
 
             _mockProviderServiceValidator.Received(1).Validate(
-                Arg.Is<ProviderServicePactFile>(x => x.Interactions.Count() == 2 && x.Interactions.All(i => i.ProviderState.Equals(providerState))), 
+                Arg.Is<ProviderServicePactFile>(x => x.Interactions.Count() == 2 && x.Interactions.All(i => i.ProviderState.Equals(providerState))),
                 Arg.Any<ProviderStates>());
         }
 
@@ -540,12 +541,12 @@ namespace PactNet.Tests
             pactVerifier.Verify(description: description, providerState: providerState);
 
             _mockProviderServiceValidator.Received(1).Validate(
-                Arg.Is<ProviderServicePactFile>(x => x.Interactions.Count() == 1 && x.Interactions.All(i => i.ProviderState.Equals(providerState) && i.Description.Equals(description))), 
+                Arg.Is<ProviderServicePactFile>(x => x.Interactions.Count() == 1 && x.Interactions.All(i => i.ProviderState.Equals(providerState) && i.Description.Equals(description))),
                 Arg.Any<ProviderStates>());
         }
 
         [Fact]
-        public void Verify_WithDescriptionThatYieldsNoInteractions_ThrowsArgumentException()
+        public async Task Verify_WithDescriptionThatYieldsNoInteractions_ThrowsArgumentException()
         {
             var description = "Description that does not match an interaction";
             var pactUri = "../../../Consumer.Tests/pacts/my_client-event_api.json";
@@ -564,9 +565,9 @@ namespace PactNet.Tests
                 .HonoursPactWith("My client")
                 .PactUri(pactUri);
 
-            Assert.Throws<ArgumentException>(() => pactVerifier.Verify(description: description));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await pactVerifier.Verify(description: description));
 
-            _mockProviderServiceValidator.DidNotReceive().Validate(
+            await _mockProviderServiceValidator.DidNotReceive().Validate(
                 Arg.Any<ProviderServicePactFile>(),
                 Arg.Any<ProviderStates>());
         }

--- a/PactNet.Tests/Reporters/ReporterTests.cs
+++ b/PactNet.Tests/Reporters/ReporterTests.cs
@@ -37,7 +37,7 @@ namespace PactNet.Tests.Reporters
         {
             const string comparisonMessage = "The thing I am testing";
 
-            var expectedMessage = String.Format("{0} (FAILED - 1)", comparisonMessage);
+            var expectedMessage = $"{comparisonMessage} (FAILED - 1)";
 
             var reporter = GetSubject();
 
@@ -55,7 +55,7 @@ namespace PactNet.Tests.Reporters
         {
             const string comparisonMessage = "The thing I am testing";
 
-            var expectedMessage = String.Format("{0} (FAILED - 1, 2)", comparisonMessage);
+            var expectedMessage = $"{comparisonMessage} (FAILED - 1, 2)";
 
             var reporter = GetSubject();
 

--- a/PactNet.Tests/app.config
+++ b/PactNet.Tests/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.28.0" newVersion="2.2.28.0" />
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/PactNet.Tests/packages.config
+++ b/PactNet.Tests/packages.config
@@ -1,14 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Nancy" version="0.23.1" targetFramework="net40" />
   <package id="Nancy.Hosting.Self" version="0.23.1" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
-  <package id="NSubstitute" version="1.7.2.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
+  <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="1.4.0.86" targetFramework="net40" />
-  <package id="xunit" version="1.9.2" targetFramework="net40" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
   <package id="xunit.runner.visualstudio" version="2.0.1" targetFramework="net40" />
 </packages>

--- a/PactNet/Comparers/ComparisonResult.cs
+++ b/PactNet/Comparers/ComparisonResult.cs
@@ -19,27 +19,12 @@ namespace PactNet.Comparers
             }
         }
 
-        public bool HasFailure
-        {
-            get
-            {
-                return Failures.Any();
-            }
-        }
+        public bool HasFailure => Failures.Any();
 
-        public int ShallowFailureCount
-        {
-            get
-            {
-                return _failures.Count();
-            }
-        }
+        public int ShallowFailureCount => _failures.Count;
 
         private readonly IList<ComparisonResult> _childResults = new List<ComparisonResult>();
-        public IEnumerable<ComparisonResult> ChildResults
-        {
-            get { return _childResults; }
-        }
+        public IEnumerable<ComparisonResult> ChildResults => _childResults;
 
         public ComparisonResult(string message = null)
         {
@@ -48,7 +33,7 @@ namespace PactNet.Comparers
 
         public ComparisonResult(string messageFormat, params object[] args)
         {
-            Message = String.Format(messageFormat, args);
+            Message = string.Format(messageFormat, args);
         }
 
         public void RecordFailure(ComparisonFailure comparisonFailure)

--- a/PactNet/Comparers/DiffComparisonFailure.cs
+++ b/PactNet/Comparers/DiffComparisonFailure.cs
@@ -6,7 +6,7 @@ namespace PactNet.Comparers
     {
         public DiffComparisonFailure(object expected, object actual)
         {
-            Result = String.Format("Expected: {0}, Actual: {1}", expected ?? "null", actual ?? "null");
+            Result = $"Expected: {expected ?? "null"}, Actual: {actual ?? "null"}";
         }
     }
 }

--- a/PactNet/Comparers/MissingInteractionComparisonFailure.cs
+++ b/PactNet/Comparers/MissingInteractionComparisonFailure.cs
@@ -9,15 +9,12 @@ namespace PactNet.Comparers
 
         public MissingInteractionComparisonFailure(ProviderServiceInteraction interaction)
         {
-            var requestMethod = interaction.Request != null ? interaction.Request.Method.ToString().ToUpperInvariant() : "No Method";
+            var requestMethod = interaction.Request?.Method.ToString().ToUpperInvariant() ?? "No Method";
             var requestPath = interaction.Request != null ? interaction.Request.Path : "No Path";
 
-            RequestDescription = String.Format("{0} {1}", requestMethod, requestPath);
-            Result = String.Format(
-                "The interaction with description '{0}' and provider state '{1}', was not used by the test. Missing request {2}.",
-                interaction.Description,
-                interaction.ProviderState,
-                RequestDescription);
+            RequestDescription = $"{requestMethod} {requestPath}";
+            Result =
+                $"The interaction with description '{interaction.Description}' and provider state '{interaction.ProviderState}', was not used by the test. Missing request {RequestDescription}.";
         }
     }
 }

--- a/PactNet/Comparers/UnexpectedRequestComparisonFailure.cs
+++ b/PactNet/Comparers/UnexpectedRequestComparisonFailure.cs
@@ -9,13 +9,11 @@ namespace PactNet.Comparers
 
         public UnexpectedRequestComparisonFailure(ProviderServiceRequest request)
         {
-            var requestMethod = request != null ? request.Method.ToString().ToUpperInvariant() : "No Method";
+            var requestMethod = request?.Method.ToString().ToUpperInvariant() ?? "No Method";
             var requestPath = request != null ? request.Path : "No Path";
 
-            RequestDescription = String.Format("{0} {1}", requestMethod, requestPath);
-            Result = String.Format(
-                "An unexpected request {0} was seen by the mock provider service.",
-                RequestDescription);
+            RequestDescription = $"{requestMethod} {requestPath}";
+            Result = $"An unexpected request {RequestDescription} was seen by the mock provider service.";
         }
     }
 }

--- a/PactNet/Configuration/Json/Converters/PreserveCasingDictionaryConverter.cs
+++ b/PactNet/Configuration/Json/Converters/PreserveCasingDictionaryConverter.cs
@@ -33,10 +33,7 @@ namespace PactNet.Configuration.Json.Converters
             throw new InvalidOperationException();
         }
 
-        public override bool CanRead
-        {
-            get { return false; }
-        }
+        public override bool CanRead => false;
 
         public override bool CanConvert(Type objectType)
         {

--- a/PactNet/Extensions/StringExtensions.cs
+++ b/PactNet/Extensions/StringExtensions.cs
@@ -6,9 +6,9 @@ namespace PactNet.Extensions
     {
         public static string ToLowerSnakeCase(this string input)
         {
-            return !String.IsNullOrEmpty(input) ?
+            return !string.IsNullOrEmpty(input) ?
                 input.Replace(' ', '_').ToLower() :
-                String.Empty;
+                string.Empty;
         }
     }
 }

--- a/PactNet/IPactVerifier.cs
+++ b/PactNet/IPactVerifier.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet
@@ -18,6 +19,6 @@ namespace PactNet
         IPactVerifier ServiceProvider(string providerName, Func<ProviderServiceRequest, ProviderServiceResponse> httpRequestSender);
         IPactVerifier HonoursPactWith(string consumerName);
         IPactVerifier PactUri(string uri, PactUriOptions options = null);
-        void Verify(string description = null, string providerState = null);
+        Task Verify(string description = null, string providerState = null);
     }
 }

--- a/PactNet/Infrastructure/Logging/LocalLogMessage.cs
+++ b/PactNet/Infrastructure/Logging/LocalLogMessage.cs
@@ -6,7 +6,7 @@ namespace PactNet.Infrastructure.Logging
     internal class LocalLogMessage
     {
         public DateTime DateTime { get; private set; }
-        public String DateTimeFormatted { get { return DateTime.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"); } }
+        public string DateTimeFormatted => DateTime.ToString("yyyy-MM-dd HH:mm:ss.fff zzz");
         public LogLevel Level { get; private set; }
         public Func<string> MessagePredicate { get; private set; }
         public Exception Exception { get; private set; }

--- a/PactNet/Infrastructure/Logging/LocalLogProvider.cs
+++ b/PactNet/Infrastructure/Logging/LocalLogProvider.cs
@@ -17,7 +17,7 @@ namespace PactNet.Infrastructure.Logging
         {
             var loggerName = GenerateUniqueLoggerName(loggerNameSeed);
 
-            var logFileName = String.Format(logFileNameTemplate, loggerName);
+            var logFileName = string.Format(logFileNameTemplate, loggerName);
             var logFilePath = Path.Combine(logDir, logFileName);
 
             lock (_sync)
@@ -45,7 +45,7 @@ namespace PactNet.Infrastructure.Logging
         {
             lock (_sync)
             {
-                if (!String.IsNullOrEmpty(name) &&
+                if (!string.IsNullOrEmpty(name) &&
                     _loggers.ContainsKey(name))
                 {
                     return _loggers[name].Log;
@@ -74,7 +74,7 @@ namespace PactNet.Infrastructure.Logging
             {
                 while (_loggers.ContainsKey(loggerName))
                 {
-                    loggerName = String.Format("{0}.{1}", nameSeed, ++count);
+                    loggerName = $"{nameSeed}.{++count}";
                 }
             }
 
@@ -91,7 +91,7 @@ namespace PactNet.Infrastructure.Logging
                 }
             }
 
-            return String.Empty;
+            return string.Empty;
         }
     }
 }

--- a/PactNet/Infrastructure/Logging/LocalLogger.cs
+++ b/PactNet/Infrastructure/Logging/LocalLogger.cs
@@ -6,7 +6,7 @@ namespace PactNet.Infrastructure.Logging
 {
     internal class LocalLogger : IDisposable
     {
-        internal string LogPath { get { return _logHandler.LogPath; } }
+        internal string LogPath => _logHandler.LogPath;
 
         private readonly ILocalLogMessageHandler _logHandler;
 
@@ -32,10 +32,7 @@ namespace PactNet.Infrastructure.Logging
 
         public void Dispose()
         {
-            if (_logHandler != null)
-            {
-                _logHandler.Dispose();
-            }
+            _logHandler?.Dispose();
         }
     }
 }

--- a/PactNet/Infrastructure/Logging/LocalRollingLogFileMessageHandler.cs
+++ b/PactNet/Infrastructure/Logging/LocalRollingLogFileMessageHandler.cs
@@ -30,16 +30,16 @@ namespace PactNet.Infrastructure.Logging
         {
             var messageFormat = logMessage.MessagePredicate != null ?
                 logMessage.MessagePredicate() :
-                String.Empty;
+                string.Empty;
 
             string message;
             if (logMessage.Exception != null)
             {
-                message = String.Format("{0}. Exception: {1} - {2}", messageFormat, logMessage.Exception, logMessage.Exception.StackTrace);
+                message = $"{messageFormat}. Exception: {logMessage.Exception} - {logMessage.Exception.StackTrace}";
             }
             else if (logMessage.FormatParameters != null && logMessage.FormatParameters.Any())
             {
-                message = String.Format(messageFormat, logMessage.FormatParameters);
+                message = string.Format(messageFormat, logMessage.FormatParameters);
             }
             else
             {
@@ -55,10 +55,7 @@ namespace PactNet.Infrastructure.Logging
 
         public void Dispose()
         {
-            if (_writer != null)
-            {
-                _writer.Dispose();
-            }
+            _writer?.Dispose();
         }
 
         private static void TryCreateDirectory(string filePath)

--- a/PactNet/Mocks/MockHttpService/Comparers/HttpHeaderComparer.cs
+++ b/PactNet/Mocks/MockHttpService/Comparers/HttpHeaderComparer.cs
@@ -40,8 +40,8 @@ namespace PactNet.Mocks.MockHttpService.Comparers
                     else
                     {
                         var expectedValueSplit = expectedValue.Split(new[] {',', ';'});
-                        var expectedValueSplitJoined = String.Join(",", expectedValueSplit.Select(x => x.Trim()));
-                        var actualValueSplitJoined = String.Join(",", actualValueSplit.Select(x => x.Trim()));
+                        var expectedValueSplitJoined = string.Join(",", expectedValueSplit.Select(x => x.Trim()));
+                        var actualValueSplitJoined = string.Join(",", actualValueSplit.Select(x => x.Trim()));
 
                         if (!expectedValueSplitJoined.Equals(actualValueSplitJoined))
                         {
@@ -51,7 +51,8 @@ namespace PactNet.Mocks.MockHttpService.Comparers
                 }
                 else
                 {
-                    headerResult.RecordFailure(new ErrorMessageComparisonFailure(String.Format("Header with key '{0}', does not exist in actual", header.Key)));
+                    headerResult.RecordFailure(new ErrorMessageComparisonFailure(
+                        $"Header with key '{header.Key}', does not exist in actual"));
                 }
 
                 result.AddChildResult(headerResult);
@@ -60,7 +61,7 @@ namespace PactNet.Mocks.MockHttpService.Comparers
             return result;
         }
 
-        private IDictionary<string, string> MakeDictionaryCaseInsensitive(IDictionary<string, string> from)
+        private static IDictionary<string, string> MakeDictionaryCaseInsensitive(IDictionary<string, string> from)
         {
             return new Dictionary<string, string>(from, StringComparer.InvariantCultureIgnoreCase);
         }

--- a/PactNet/Mocks/MockHttpService/Comparers/HttpQueryStringComparer.cs
+++ b/PactNet/Mocks/MockHttpService/Comparers/HttpQueryStringComparer.cs
@@ -10,7 +10,7 @@ namespace PactNet.Mocks.MockHttpService.Comparers
     {
         public ComparisonResult Compare(string expected, string actual)
         {
-            if (String.IsNullOrEmpty(expected) && String.IsNullOrEmpty(actual))
+            if (string.IsNullOrEmpty(expected) && string.IsNullOrEmpty(actual))
             {
                 return new ComparisonResult("has no query strings");
             }

--- a/PactNet/Mocks/MockHttpService/CustomRequestSender.cs
+++ b/PactNet/Mocks/MockHttpService/CustomRequestSender.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet.Mocks.MockHttpService
@@ -12,9 +13,9 @@ namespace PactNet.Mocks.MockHttpService
             _httpRequestSenderFunc = httpRequestSenderFunc;
         }
 
-        public ProviderServiceResponse Send(ProviderServiceRequest request)
+        public Task<ProviderServiceResponse> Send(ProviderServiceRequest request)
         {
-            return _httpRequestSenderFunc(request);
+            return Task.FromResult(_httpRequestSenderFunc(request));
         }
     }
 }

--- a/PactNet/Mocks/MockHttpService/HttpClientRequestSender.cs
+++ b/PactNet/Mocks/MockHttpService/HttpClientRequestSender.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService.Mappers;
 using PactNet.Mocks.MockHttpService.Models;
 
@@ -11,10 +12,10 @@ namespace PactNet.Mocks.MockHttpService
         private readonly HttpClient _httpClient;
         private readonly IHttpRequestMessageMapper _httpRequestMessageMapper;
         private readonly IProviderServiceResponseMapper _providerServiceResponseMapper;
-        
+
         internal HttpClientRequestSender(
-            HttpClient httpClient, 
-            IHttpRequestMessageMapper httpRequestMessageMapper, 
+            HttpClient httpClient,
+            IHttpRequestMessageMapper httpRequestMessageMapper,
             IProviderServiceResponseMapper providerServiceResponseMapper)
         {
             _httpClient = httpClient;
@@ -27,7 +28,7 @@ namespace PactNet.Mocks.MockHttpService
         {
         }
 
-        public ProviderServiceResponse Send(ProviderServiceRequest request)
+        public async Task<ProviderServiceResponse> Send(ProviderServiceRequest request)
         {
             //Added because of this http://stackoverflow.com/questions/23438416/why-is-httpclient-baseaddress-not-working
             if (_httpClient.BaseAddress != null && _httpClient.BaseAddress.OriginalString.EndsWith("/"))
@@ -37,21 +38,18 @@ namespace PactNet.Mocks.MockHttpService
 
             var httpRequest = _httpRequestMessageMapper.Convert(request);
 
-            var httpResponse = _httpClient.SendAsync(httpRequest, CancellationToken.None).Result;
+            var httpResponse = await _httpClient.SendAsync(httpRequest, CancellationToken.None);
             var response = _providerServiceResponseMapper.Convert(httpResponse);
 
             Dispose(httpRequest);
             Dispose(httpResponse);
 
-            return response;
+            return await response;
         }
 
         private static void Dispose(IDisposable disposable)
         {
-            if (disposable != null)
-            {
-                disposable.Dispose();
-            }
+            disposable?.Dispose();
         }
     }
 }

--- a/PactNet/Mocks/MockHttpService/IHttpRequestSender.cs
+++ b/PactNet/Mocks/MockHttpService/IHttpRequestSender.cs
@@ -1,9 +1,10 @@
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet.Mocks.MockHttpService
 {
     internal interface IHttpRequestSender
     {
-        ProviderServiceResponse Send(ProviderServiceRequest request);
+        Task<ProviderServiceResponse> Send(ProviderServiceRequest request);
     }
 }

--- a/PactNet/Mocks/MockHttpService/IMockProviderService.cs
+++ b/PactNet/Mocks/MockHttpService/IMockProviderService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet.Mocks.MockHttpService
@@ -6,11 +7,11 @@ namespace PactNet.Mocks.MockHttpService
     public interface IMockProviderService : IMockProvider<IMockProviderService>
     {
         IMockProviderService With(ProviderServiceRequest request);
-        void WillRespondWith(ProviderServiceResponse response);
+        Task WillRespondWith(ProviderServiceResponse response);
         void Start();
         void Stop();
         void ClearInteractions();
         void VerifyInteractions();
-        void SendAdminHttpRequest<T>(HttpVerb method, string path, T requestContent, IDictionary<string, string> headers = null) where T : class;
+        Task SendAdminHttpRequest<T>(HttpVerb method, string path, T requestContent, IDictionary<string, string> headers = null) where T : class;
     }
 }

--- a/PactNet/Mocks/MockHttpService/Mappers/HttpMethodMapper.cs
+++ b/PactNet/Mocks/MockHttpService/Mappers/HttpMethodMapper.cs
@@ -21,7 +21,8 @@ namespace PactNet.Mocks.MockHttpService.Mappers
         {
             if (!Map.ContainsKey(from))
             {
-                throw new ArgumentException(String.Format("Cannot map HttpVerb.{0} to a HttpMethod, no matching item has been registered.", from));
+                throw new ArgumentException(
+                    $"Cannot map HttpVerb.{@from} to a HttpMethod, no matching item has been registered.");
             }
 
             return Map[from];

--- a/PactNet/Mocks/MockHttpService/Mappers/HttpVerbMapper.cs
+++ b/PactNet/Mocks/MockHttpService/Mappers/HttpVerbMapper.cs
@@ -20,7 +20,7 @@ namespace PactNet.Mocks.MockHttpService.Mappers
         {
             if (!Map.ContainsKey(from))
             {
-                throw new ArgumentException(String.Format("Cannot map {0} to a HttpVerb, no matching item has been registered.", from));
+                throw new ArgumentException($"Cannot map {@from} to a HttpVerb, no matching item has been registered.");
             }
 
             return Map[from];

--- a/PactNet/Mocks/MockHttpService/Mappers/IProviderServiceResponseMapper.cs
+++ b/PactNet/Mocks/MockHttpService/Mappers/IProviderServiceResponseMapper.cs
@@ -1,10 +1,12 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 using PactNet.Mappers;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet.Mocks.MockHttpService.Mappers
 {
-    internal interface IProviderServiceResponseMapper : IMapper<HttpResponseMessage, ProviderServiceResponse>
+    internal interface IProviderServiceResponseMapper
     {
+        Task<ProviderServiceResponse> Convert(HttpResponseMessage msg);
     }
 }

--- a/PactNet/Mocks/MockHttpService/Mappers/ProviderServiceRequestMapper.cs
+++ b/PactNet/Mocks/MockHttpService/Mappers/ProviderServiceRequestMapper.cs
@@ -38,12 +38,12 @@ namespace PactNet.Mocks.MockHttpService.Mappers
             {
                 Method = httpVerb,
                 Path = from.Path,
-                Query = !String.IsNullOrEmpty(from.Url.Query) ? from.Url.Query.TrimStart('?') : null
+                Query = !string.IsNullOrEmpty(from.Url.Query) ? from.Url.Query.TrimStart('?') : null
             };
 
             if (from.Headers != null && from.Headers.Any())
             {
-                var fromHeaders = from.Headers.ToDictionary(x => x.Key, x => String.Join(", ", x.Value));
+                var fromHeaders = from.Headers.ToDictionary(x => x.Key, x => string.Join(", ", x.Value));
                 to.Headers = fromHeaders;
             }
 

--- a/PactNet/Mocks/MockHttpService/Mappers/ProviderServiceResponseMapper.cs
+++ b/PactNet/Mocks/MockHttpService/Mappers/ProviderServiceResponseMapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using PactNet.Mocks.MockHttpService.Models;
 
 namespace PactNet.Mocks.MockHttpService.Mappers
@@ -19,10 +20,10 @@ namespace PactNet.Mocks.MockHttpService.Mappers
         public ProviderServiceResponseMapper() : this(
             new HttpBodyContentMapper())
         {
-            
+
         }
 
-        public ProviderServiceResponse Convert(HttpResponseMessage from)
+        public async Task<ProviderServiceResponse> Convert(HttpResponseMessage from)
         {
             if (from == null)
             {
@@ -31,13 +32,13 @@ namespace PactNet.Mocks.MockHttpService.Mappers
 
             var to = new ProviderServiceResponse
             {
-                Status = (int) from.StatusCode,
+                Status = (int)from.StatusCode,
                 Headers = ConvertHeaders(from.Headers, from.Content)
             };
 
-            if(from.Content != null)
+            if (from.Content != null)
             {
-                var responseContent = from.Content.ReadAsByteArrayAsync().Result;
+                var responseContent = await from.Content.ReadAsByteArrayAsync();
                 if (responseContent != null)
                 {
                     var httpBodyContent = _httpBodyContentMapper.Convert(content: responseContent, headers: to.Headers);
@@ -63,15 +64,15 @@ namespace PactNet.Mocks.MockHttpService.Mappers
             {
                 foreach (var responseHeader in responseHeaders)
                 {
-                    headers.Add(responseHeader.Key, String.Join(", ", responseHeader.Value.Select(x => x)));
+                    headers.Add(responseHeader.Key, string.Join(", ", responseHeader.Value.Select(x => x)));
                 }
             }
 
-            if (httpContent != null && httpContent.Headers != null && httpContent.Headers.Any())
+            if (httpContent?.Headers != null && httpContent.Headers.Any())
             {
                 foreach (var contentHeader in httpContent.Headers)
                 {
-                    headers.Add(contentHeader.Key, String.Join(", ", contentHeader.Value.Select(x => x)));
+                    headers.Add(contentHeader.Key, string.Join(", ", contentHeader.Value.Select(x => x)));
                 }
             }
 

--- a/PactNet/Mocks/MockHttpService/MockProviderRepository.cs
+++ b/PactNet/Mocks/MockHttpService/MockProviderRepository.cs
@@ -37,7 +37,8 @@ namespace PactNet.Mocks.MockHttpService
             if (_testScopedInteractions.Any(x => x.Description == interaction.Description &&
                 x.ProviderState == interaction.ProviderState))
             {
-                throw new PactFailureException(String.Format("An interaction already exists with the description '{0}' and provider state '{1}' in this test. Please supply a different description or provider state.", interaction.Description, interaction.ProviderState));
+                throw new PactFailureException(
+                    $"An interaction already exists with the description '{interaction.Description}' and provider state '{interaction.ProviderState}' in this test. Please supply a different description or provider state.");
             }
 
             //From a Pact specification perspective, I should de-dupe any interactions that have been registered by another test as long as they match exactly!
@@ -49,7 +50,8 @@ namespace PactNet.Mocks.MockHttpService
             else if (duplicateInteractions.Any(di => di.AsJsonString() != interaction.AsJsonString()))
             {
                 //If the interaction description and provider state match, however anything else in the interaction is different, throw
-                throw new PactFailureException(String.Format("An interaction registered by another test already exists with the description '{0}' and provider state '{1}', however the interaction does not match exactly. Please supply a different description or provider state. Alternatively align this interaction to match the duplicate exactly.", interaction.Description, interaction.ProviderState));
+                throw new PactFailureException(
+                    $"An interaction registered by another test already exists with the description '{interaction.Description}' and provider state '{interaction.ProviderState}', however the interaction does not match exactly. Please supply a different description or provider state. Alternatively align this interaction to match the duplicate exactly.");
             }
 
             _testScopedInteractions.Add(interaction);
@@ -69,7 +71,8 @@ namespace PactNet.Mocks.MockHttpService
         {
             if (TestScopedInteractions == null || !TestScopedInteractions.Any())
             {
-                throw new PactFailureException(String.Format("No interaction found for {0} {1}.", request.Method.ToString().ToUpperInvariant(), request.Path));
+                throw new PactFailureException(
+                    $"No interaction found for {request.Method.ToString().ToUpperInvariant()} {request.Path}.");
             }
 
             var matchingInteractions = new List<ProviderServiceInteraction>();
@@ -85,12 +88,14 @@ namespace PactNet.Mocks.MockHttpService
 
             if (matchingInteractions == null || !matchingInteractions.Any())
             {
-                throw new PactFailureException(String.Format("No interaction found for {0} {1}.", request.Method.ToString().ToUpperInvariant(), request.Path));
+                throw new PactFailureException(
+                    $"No interaction found for {request.Method.ToString().ToUpperInvariant()} {request.Path}.");
             }
 
-            if (matchingInteractions.Count() > 1)
+            if (matchingInteractions.Count > 1)
             {
-                throw new PactFailureException(String.Format("More than one interaction found for {0} {1}.", request.Method.ToString().ToUpperInvariant(), request.Path));
+                throw new PactFailureException(
+                    $"More than one interaction found for {request.Method.ToString().ToUpperInvariant()} {request.Path}.");
             }
 
             return matchingInteractions.Single();

--- a/PactNet/Mocks/MockHttpService/Models/ProviderServiceRequest.cs
+++ b/PactNet/Mocks/MockHttpService/Models/ProviderServiceRequest.cs
@@ -59,14 +59,14 @@ namespace PactNet.Mocks.MockHttpService.Models
 
         public string PathWithQuery()
         {
-            if (String.IsNullOrEmpty(Path) && !String.IsNullOrEmpty(Query))
+            if (string.IsNullOrEmpty(Path) && !string.IsNullOrEmpty(Query))
             {
                 throw new InvalidOperationException("Query has been supplied, however Path has not. Please specify as Path.");
             }
 
-            return !String.IsNullOrEmpty(Query) ?
-                    String.Format("{0}?{1}", Path, Query) :
-                    Path;
+            return !string.IsNullOrEmpty(Query) ?
+                $"{Path}?{Query}" :
+                Path;
         }
     }
 }

--- a/PactNet/Mocks/MockHttpService/Nancy/MockProviderAdminRequestHandler.cs
+++ b/PactNet/Mocks/MockHttpService/Nancy/MockProviderAdminRequestHandler.cs
@@ -36,7 +36,7 @@ namespace PactNet.Mocks.MockHttpService.Nancy
         public Response Handle(NancyContext context)
         {
             //The first admin request with test context, we should log the context
-            if (String.IsNullOrEmpty(_mockProviderRepository.TestContext) &&
+            if (string.IsNullOrEmpty(_mockProviderRepository.TestContext) &&
                 context.Request.Headers != null &&
                 context.Request.Headers.Any(x => x.Key == Constants.AdministrativeRequestTestContextHeaderKey))
             {
@@ -69,7 +69,7 @@ namespace PactNet.Mocks.MockHttpService.Nancy
             }
 
             return GenerateResponse(HttpStatusCode.NotFound,
-                String.Format("The {0} request for path {1}, does not have a matching mock provider admin action.", context.Request.Method, context.Request.Path));
+                $"The {context.Request.Method} request for path {context.Request.Path}, does not have a matching mock provider admin action.");
         }
 
         private Response HandleDeleteInteractionsRequest()
@@ -112,7 +112,8 @@ namespace PactNet.Mocks.MockHttpService.Nancy
                     }
                     else if (interactionUsages.Count() > 1)
                     {
-                        comparisonResult.RecordFailure(new ErrorMessageComparisonFailure(String.Format("The interaction with description '{0}' and provider state '{1}', was used {2} time/s by the test.", registeredInteraction.Description, registeredInteraction.ProviderState, interactionUsages.Count())));
+                        comparisonResult.RecordFailure(new ErrorMessageComparisonFailure(
+                            $"The interaction with description '{registeredInteraction.Description}' and provider state '{registeredInteraction.ProviderState}', was used {interactionUsages.Count()} time/s by the test."));
                     }
                 }
             }
@@ -145,7 +146,7 @@ namespace PactNet.Mocks.MockHttpService.Nancy
 
             if (comparisonResult.Failures.Any(x => x is MissingInteractionComparisonFailure))
             {
-                _log.Error("Missing requests: " + String.Join(", ", 
+                _log.Error("Missing requests: " + string.Join(", ", 
                     comparisonResult.Failures
                         .Where(x => x is MissingInteractionComparisonFailure)
                         .Cast<MissingInteractionComparisonFailure>()
@@ -154,7 +155,7 @@ namespace PactNet.Mocks.MockHttpService.Nancy
 
             if (comparisonResult.Failures.Any(x => x is UnexpectedRequestComparisonFailure))
             {
-                _log.Error("Unexpected requests: " + String.Join(", ", 
+                _log.Error("Unexpected requests: " + string.Join(", ", 
                     comparisonResult.Failures
                         .Where(x => x is UnexpectedRequestComparisonFailure)
                         .Cast<UnexpectedRequestComparisonFailure>()

--- a/PactNet/Mocks/MockHttpService/Nancy/MockProviderNancyRequestDispatcher.cs
+++ b/PactNet/Mocks/MockHttpService/Nancy/MockProviderNancyRequestDispatcher.cs
@@ -60,9 +60,8 @@ namespace PactNet.Mocks.MockHttpService.Nancy
                     _log.ErrorException("Failed to handle the request", ex);
                 }
 
-                var exceptionMessage = String.Format("{0} See {1} for details.", 
-                    JsonConvert.ToString(ex.Message).Trim('"'), 
-                    !String.IsNullOrEmpty(_pactConfig.LoggerName) ? LogProvider.CurrentLogProvider.ResolveLogPath(_pactConfig.LoggerName) : "logs");
+                var exceptionMessage =
+                    $"{JsonConvert.ToString(ex.Message).Trim('"')} See {(!string.IsNullOrEmpty(_pactConfig.LoggerName) ? LogProvider.CurrentLogProvider.ResolveLogPath(_pactConfig.LoggerName) : "logs")} for details.";
 
                 response = new Response
                 {

--- a/PactNet/Models/PactDetails.cs
+++ b/PactNet/Models/PactDetails.cs
@@ -14,10 +14,9 @@ namespace PactNet.Models
 
         public string GeneratePactFileName()
         {
-            return String.Format("{0}-{1}.json", 
-                Consumer != null ? Consumer.Name : String.Empty,
-                Provider != null ? Provider.Name : String.Empty)
-                .ToLowerSnakeCase();
+            return
+                $"{(Consumer != null ? Consumer.Name : string.Empty)}-{(Provider != null ? Provider.Name : string.Empty)}.json"
+                    .ToLowerSnakeCase();
         }
     }
 }

--- a/PactNet/Models/ProviderStates.cs
+++ b/PactNet/Models/ProviderStates.cs
@@ -23,7 +23,8 @@ namespace PactNet.Models
 
             if (_providerStates.Any(x => x.ProviderStateDescription == providerState.ProviderStateDescription))
             {
-                throw new ArgumentException(String.Format("providerState '{0}' has already been added", providerState.ProviderStateDescription));
+                throw new ArgumentException(
+                    $"providerState '{providerState.ProviderStateDescription}' has already been added");
             }
 
             _providerStates.Add(providerState);
@@ -36,12 +37,7 @@ namespace PactNet.Models
                 throw new ArgumentNullException("Please supply a non null providerState");
             }
 
-            if (_providerStates != null && _providerStates.Any(x => x.ProviderStateDescription == providerState))
-            {
-                return _providerStates.FirstOrDefault(x => x.ProviderStateDescription == providerState);
-            }
-
-            return null;
+            return _providerStates?.FirstOrDefault(x => x.ProviderStateDescription == providerState);
         }
     }
 }

--- a/PactNet/PactBuilder.cs
+++ b/PactNet/PactBuilder.cs
@@ -31,7 +31,7 @@ namespace PactNet
 
         public IPactBuilder ServiceConsumer(string consumerName)
         {
-            if (String.IsNullOrEmpty(consumerName))
+            if (string.IsNullOrEmpty(consumerName))
             {
                 throw new ArgumentException("Please supply a non null or empty consumerName");
             }
@@ -43,7 +43,7 @@ namespace PactNet
 
         public IPactBuilder HasPactWith(string providerName)
         {
-            if (String.IsNullOrEmpty(providerName))
+            if (string.IsNullOrEmpty(providerName))
             {
                 throw new ArgumentException("Please supply a non null or empty providerName");
             }
@@ -57,14 +57,11 @@ namespace PactNet
         {
             return MockService(port, jsonSerializerSettings: null, enableSsl: enableSsl, bindOnAllAdapters: bindOnAllAdapters);
         }
-    
+
 
         public IMockProviderService MockService(int port, JsonSerializerSettings jsonSerializerSettings, bool enableSsl = false, bool bindOnAllAdapters = false)
         {
-            if (_mockProviderService != null)
-            {
-                _mockProviderService.Stop();
-            }
+            _mockProviderService?.Stop();
 
             if (jsonSerializerSettings != null)
             {
@@ -91,12 +88,12 @@ namespace PactNet
 
         private void PersistPactFile()
         {
-            if (String.IsNullOrEmpty(ConsumerName))
+            if (string.IsNullOrEmpty(ConsumerName))
             {
                 throw new InvalidOperationException("ConsumerName has not been set, please supply a consumer name using the ServiceConsumer method.");
             }
 
-            if (String.IsNullOrEmpty(ProviderName))
+            if (string.IsNullOrEmpty(ProviderName))
             {
                 throw new InvalidOperationException("ProviderName has not been set, please supply a provider name using the HasPactWith method.");
             }

--- a/PactNet/PactNet.csproj
+++ b/PactNet/PactNet.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PactNet</RootNamespace>
     <AssemblyName>PactNet</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -27,6 +27,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\PactNet.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,6 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\PactNet.XML</DocumentationFile>
     <NoWarn>1591</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject />
@@ -51,41 +53,26 @@
       <HintPath>..\packages\Nancy.Hosting.Self.0.23.1\lib\net40\Nancy.Hosting.Self.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.IO">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.IO.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.IO.Abstractions, Version=1.4.0.86, Culture=neutral, PublicKeyToken=d480b5b72fb413da, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\System.IO.Abstractions.1.4.0.86\lib\net35\System.IO.Abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.Extensions.dll</HintPath>
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.Primitives.dll</HintPath>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.WebRequest, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net40\System.Net.Http.WebRequest.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Runtime.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\packages\Microsoft.Bcl.1.1.9\lib\net40\System.Threading.Tasks.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Configuration\Json\Converters\CamelCaseStringEnumConverter.cs" />
@@ -204,11 +191,6 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -216,6 +198,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/PactNet/PactUriOptions.cs
+++ b/PactNet/PactUriOptions.cs
@@ -9,24 +9,13 @@ namespace PactNet
         private readonly string _username;
         private readonly string _password;
 
-        internal string AuthorizationScheme
-        {
-            get { return AuthScheme; }
-        }
+        internal string AuthorizationScheme => AuthScheme;
 
-        internal string AuthorizationValue
-        {
-            get
-            {
-                return Convert.ToBase64String(
-                    Encoding.UTF8.GetBytes(
-                    String.Format("{0}:{1}", _username, _password)));
-            }
-        }
+        internal string AuthorizationValue => Convert.ToBase64String(Encoding.UTF8.GetBytes($"{_username}:{_password}"));
 
         public PactUriOptions(string username, string password)
         {
-            if (String.IsNullOrEmpty(username))
+            if (string.IsNullOrEmpty(username))
             {
                 throw new ArgumentException("username is null or empty.");
             }
@@ -36,7 +25,7 @@ namespace PactNet
                 throw new ArgumentException("username contains a ':' character, which is not allowed.");
             }
 
-            if (String.IsNullOrEmpty(password))
+            if (string.IsNullOrEmpty(password))
             {
                 throw new ArgumentException("password is null or empty.");
             }

--- a/PactNet/Reporters/Reporter.cs
+++ b/PactNet/Reporters/Reporter.cs
@@ -61,7 +61,7 @@ namespace PactNet.Reporters
 
             foreach (var outputter in _outputters)
             {
-                outputter.Write(String.Join(Environment.NewLine, _reportLines));
+                outputter.Write(string.Join(Environment.NewLine, _reportLines));
             }
         }
 
@@ -116,19 +116,19 @@ namespace PactNet.Reporters
                 return;
             }
 
-            AddReportLine(String.Empty, 0);
+            AddReportLine(string.Empty, 0);
             AddReportLine("Failures:", 0);
 
             foreach (var failure in comparisonResult.Failures)
             {
-                AddReportLine(String.Empty, 0);
-                AddReportLine(String.Format("{0}) {1}", ++_failureCount, failure.Result), 0);
+                AddReportLine(string.Empty, 0);
+                AddReportLine($"{++_failureCount}) {failure.Result}", 0);
             }
         }
 
         private void AddReportLine(string message, int tabDepth)
         {
-            var indentation = new String(' ', tabDepth*2); //Each tab we want to be 2 space chars
+            var indentation = new string(' ', tabDepth*2); //Each tab we want to be 2 space chars
             _reportLines.Add(indentation + message);
         }
     }

--- a/PactNet/Validators/IPactValidator.cs
+++ b/PactNet/Validators/IPactValidator.cs
@@ -1,9 +1,10 @@
-﻿using PactNet.Models;
+﻿using System.Threading.Tasks;
+using PactNet.Models;
 
 namespace PactNet.Validators
 {
     internal interface IPactValidator<in TPactFile> where TPactFile : PactFile
     {
-        void Validate(TPactFile pactFile, ProviderStates providerStates);
+        Task Validate(TPactFile pactFile, ProviderStates providerStates);
     }
 }

--- a/PactNet/app.config
+++ b/PactNet/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.2.28.0" newVersion="2.2.28.0" />
+        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/PactNet/packages.config
+++ b/PactNet/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="LibLog" version="4.2.2" targetFramework="net40" />
-  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net40" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net40" />
+  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Nancy" version="0.23.1" targetFramework="net40" />
   <package id="Nancy.Hosting.Self" version="0.23.1" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="1.4.0.86" targetFramework="net40" />
 </packages>

--- a/Samples/EventApi/Consumer.Tests/Consumer.Tests.csproj
+++ b/Samples/EventApi/Consumer.Tests/Consumer.Tests.csproj
@@ -35,8 +35,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -46,12 +46,26 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConsumerEventApiPact.cs" />
+    <Compile Include="ConsumerTestCollection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EventsApiConsumerTests.cs" />
   </ItemGroup>

--- a/Samples/EventApi/Consumer.Tests/ConsumerEventApiPact.cs
+++ b/Samples/EventApi/Consumer.Tests/ConsumerEventApiPact.cs
@@ -10,7 +10,7 @@ namespace Consumer.Tests
         public IMockProviderService MockProviderService { get; private set; }
 
         public int MockServerPort { get { return 1234; } }
-        public string MockProviderServiceBaseUri { get { return String.Format("http://localhost:{0}", MockServerPort); } }
+        public string MockProviderServiceBaseUri { get { return $"http://localhost:{MockServerPort}"; } }
 
         public ConsumerEventApiPact()
         {

--- a/Samples/EventApi/Consumer.Tests/ConsumerTestCollection.cs
+++ b/Samples/EventApi/Consumer.Tests/ConsumerTestCollection.cs
@@ -1,0 +1,9 @@
+﻿using Xunit;
+
+namespace Consumer.Tests
+{
+    [CollectionDefinition("Consumer test collection")]
+    public class ConsumerTestCollection : ICollectionFixture<ConsumerEventApiPact>
+    {
+    }
+}

--- a/Samples/EventApi/Consumer.Tests/packages.config
+++ b/Samples/EventApi/Consumer.Tests/packages.config
@@ -2,5 +2,10 @@
 <packages>
   <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net45" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/Samples/EventApi/Consumer.Tests/pacts/consumer-event_api.json
+++ b/Samples/EventApi/Consumer.Tests/pacts/consumer-event_api.json
@@ -7,59 +7,17 @@
   },
   "interactions": [
     {
-      "description": "a request to get a new blob by id",
-      "request": {
-        "method": "get",
-        "path": "/blobs/38c3976b-5ae8-4f2f-a8ec-46f6aee826e2"
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "text/plain"
-        },
-        "body": "This is a test"
-      }
-    },
-    {
-      "description": "a request to create a new event",
+      "description": "a request to create a new blob",
       "request": {
         "method": "post",
-        "path": "/events",
+        "path": "/blobs/38c3976b-5ae8-4f2f-a8ec-46f6aee826e2",
         "headers": {
-          "Content-Type": "application/json; charset=utf-8"
+          "Content-Type": "application/octet-stream"
         },
-        "body": {
-          "eventId": "1f587704-2dcc-4313-a233-7b62b4b469db",
-          "timestamp": "2011-07-01T01:41:03",
-          "eventType": "DetailsView"
-        }
+        "body": "VGhpcyBpcyBhIHRlc3Q="
       },
       "response": {
         "status": 201
-      }
-    },
-    {
-      "description": "a request to retrieve events with type 'DetailsView'",
-      "provider_state": "there is one event with type 'DetailsView'",
-      "request": {
-        "method": "get",
-        "path": "/events",
-        "query": "type=DetailsView",
-        "headers": {
-          "Accept": "application/json"
-        },
-        "body": null
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/json; charset=utf-8"
-        },
-        "body": [
-          {
-            "eventType": "DetailsView"
-          }
-        ]
       }
     },
     {
@@ -87,6 +45,20 @@
       }
     },
     {
+      "description": "a request to get a new blob by id",
+      "request": {
+        "method": "get",
+        "path": "/blobs/38c3976b-5ae8-4f2f-a8ec-46f6aee826e2"
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "text/plain"
+        },
+        "body": "This is a test"
+      }
+    },
+    {
       "description": "a request to check the api uptime",
       "request": {
         "method": "get",
@@ -102,6 +74,26 @@
         },
         "body": {
           "upSince": "2014-06-27T23:51:12Z"
+        }
+      }
+    },
+    {
+      "description": "a request to retrieve event with id '83f9262f-28f1-4703-ab1a-8cfd9e8249c9'",
+      "provider_state": "there is an event with id '83f9262f-28f1-4703-ab1a-8cfd9e8249c9'",
+      "request": {
+        "method": "get",
+        "path": "/events/83f9262f-28f1-4703-ab1a-8cfd9e8249c9",
+        "headers": {
+          "Accept": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json; charset=utf-8"
+        },
+        "body": {
+          "eventId": "83f9262f-28f1-4703-ab1a-8cfd9e8249c9"
         }
       }
     },
@@ -123,6 +115,30 @@
         "body": {
           "message": "Authorization has been denied for this request."
         }
+      }
+    },
+    {
+      "description": "a request to retrieve events with type 'DetailsView'",
+      "provider_state": "there is one event with type 'DetailsView'",
+      "request": {
+        "method": "get",
+        "path": "/events",
+        "query": "type=DetailsView",
+        "headers": {
+          "Accept": "application/json"
+        },
+        "body": null
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json; charset=utf-8"
+        },
+        "body": [
+          {
+            "eventType": "DetailsView"
+          }
+        ]
       }
     },
     {
@@ -161,37 +177,21 @@
       }
     },
     {
-      "description": "a request to create a new blob",
+      "description": "a request to create a new event",
       "request": {
         "method": "post",
-        "path": "/blobs/38c3976b-5ae8-4f2f-a8ec-46f6aee826e2",
-        "headers": {
-          "Content-Type": "application/octet-stream"
-        },
-        "body": "VGhpcyBpcyBhIHRlc3Q="
-      },
-      "response": {
-        "status": 201
-      }
-    },
-    {
-      "description": "a request to retrieve event with id '83f9262f-28f1-4703-ab1a-8cfd9e8249c9'",
-      "provider_state": "there is an event with id '83f9262f-28f1-4703-ab1a-8cfd9e8249c9'",
-      "request": {
-        "method": "get",
-        "path": "/events/83f9262f-28f1-4703-ab1a-8cfd9e8249c9",
-        "headers": {
-          "Accept": "application/json"
-        }
-      },
-      "response": {
-        "status": 200,
+        "path": "/events",
         "headers": {
           "Content-Type": "application/json; charset=utf-8"
         },
         "body": {
-          "eventId": "83f9262f-28f1-4703-ab1a-8cfd9e8249c9"
+          "eventId": "1f587704-2dcc-4313-a233-7b62b4b469db",
+          "timestamp": "2011-07-01T01:41:03",
+          "eventType": "DetailsView"
         }
+      },
+      "response": {
+        "status": 201
       }
     }
   ],

--- a/Samples/EventApi/Consumer/Consumer.csproj
+++ b/Samples/EventApi/Consumer/Consumer.csproj
@@ -34,8 +34,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Samples/EventApi/Provider.Api.Web.Tests/EventAPITests.cs
+++ b/Samples/EventApi/Provider.Api.Web.Tests/EventAPITests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Owin.Security.DataProtection;
 using Microsoft.Owin.Security.OAuth;
 using Microsoft.Owin.Testing;
@@ -11,15 +12,15 @@ namespace Provider.Api.Web.Tests
     public class EventApiTests : IDisposable
     {
         private TestServer _server;
-        
+
         [Fact]
-        public void EnsureEventApiHonoursPactWithConsumer()
+        public async Task EnsureEventApiHonoursPactWithConsumer()
         {
             //Arrange
             var outputter = new CustomOutputter();
             var config = new PactVerifierConfig();
             config.ReportOutputters.Add(outputter);
-            IPactVerifier pactVerifier = new PactVerifier(() => {}, () => {}, config);
+            IPactVerifier pactVerifier = new PactVerifier(() => { }, () => { }, config);
 
             pactVerifier
                 .ProviderState(
@@ -38,7 +39,7 @@ namespace Provider.Api.Web.Tests
             });
 
             //Act / Assert
-            pactVerifier
+            await pactVerifier
                    .ServiceProvider("Event API", _server.HttpClient)
                    .HonoursPactWith("Consumer")
                    .PactUri("../../../Consumer.Tests/pacts/consumer-event_api.json")
@@ -63,7 +64,7 @@ namespace Provider.Api.Web.Tests
             //Logic to do database inserts for event with id 83F9262F-28F1-4703-AB1A-8CFD9E8249C9
         }
 
-    
+
         public virtual void Dispose()
         {
             if (_server != null)

--- a/Samples/EventApi/Provider.Api.Web.Tests/Provider.Api.Web.Tests.csproj
+++ b/Samples/EventApi/Provider.Api.Web.Tests/Provider.Api.Web.Tests.csproj
@@ -63,11 +63,13 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xml.Linq" />
@@ -75,8 +77,21 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="xunit">
-      <HintPath>..\..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -103,11 +118,6 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
-  </Target>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -115,6 +125,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
+  <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Samples/EventApi/Provider.Api.Web.Tests/packages.config
+++ b/Samples/EventApi/Provider.Api.Web.Tests/packages.config
@@ -11,5 +11,10 @@
   <package id="Microsoft.Owin.Testing" version="2.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/Samples/EventApi/Provider.Api.Web/Controllers/BlobsController.cs
+++ b/Samples/EventApi/Provider.Api.Web/Controllers/BlobsController.cs
@@ -3,6 +3,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Threading.Tasks;
 using System.Web.Http;
 
 namespace Provider.Api.Web.Controllers
@@ -27,16 +28,16 @@ namespace Provider.Api.Web.Controllers
 
         [HttpPost]
         [Route("blobs/{id}")]
-        public HttpResponseMessage Post(Guid id)
+        public async Task<HttpResponseMessage> Post(Guid id)
         {
-            var bytes = Request.Content.ReadAsByteArrayAsync().Result;
+            var bytes = await Request.Content.ReadAsByteArrayAsync();
             var requestBody = Encoding.UTF8.GetString(bytes);
 
             if (requestBody != Data)
             {
                 return new HttpResponseMessage(HttpStatusCode.BadRequest);
             }
-            
+
             return new HttpResponseMessage(HttpStatusCode.Created);
         }
     }


### PR DESCRIPTION

We started using your library some time ago, but recently we met the problem described here http://stackoverflow.com/questions/32005912/running-xunit-tests-on-teamcity-using-async-methods 
Our XUnit2 test when running in parallel (default option) falls into deadlocks on some automated build agents (it's very hard to reproduce in local environments).
This pull request reflects the changes we made to the library to utilize async methods of HttpClient properly and get rid of a problem:
1. Target .NET 4.5
2. Use async/await all the way down 
3. Update xunit to 2.1 make async methods testing easier
