### PR TITLE
Fix response body json string handling

### DIFF
--- a/PactNet.Tests/Mocks/MockHttpService/Models/HttpBodyContentTests.cs
+++ b/PactNet.Tests/Mocks/MockHttpService/Models/HttpBodyContentTests.cs
@@ -86,7 +86,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Models
         }
 
         [Fact]
-        public void Ctor1_WithJsonBody_SetsBodyAndContent()
+        public void Ctor1_WithJsonObjectBody_SetsBodyAndContent()
         {
             var body = new
             {
@@ -100,8 +100,60 @@ namespace PactNet.Tests.Mocks.MockHttpService.Models
             Assert.Equal(body, httpBodyContent.Body);
         }
 
+
         [Fact]
-        public void Ctor1_WithJsonBodyAndTitleCasedContentType_SetsBodyAndContent()
+        public void Ctor1_WithJsonArrayBody_SetsBodyAndContent()
+        {
+            var body = new[] {
+                new {
+                    Test = "tester",
+                    tesTer = 1
+                }
+            };
+            const string content = "[{\"Test\":\"tester\",\"tesTer\":1}]";
+            var httpBodyContent = new HttpBodyContent(body: body, contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(body, httpBodyContent.Body);
+        }
+
+        [Fact]
+        public void Ctor1_WithJsonStringBody_SetsBodyAndContent()
+        {
+            const string bodyIn = "Some json string body";
+            const string bodyOut = "\"Some json string body\"";
+            const string content = "\"Some json string body\"";
+            var httpBodyContent = new HttpBodyContent(body: bodyIn, contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(bodyOut, (string)httpBodyContent.Body);
+        }
+
+        [Fact]
+        public void Ctor1_WithJsonIntBody_SetsBodyAndContent()
+        {
+            const int body = 5;
+            const string content = "5";
+            var httpBodyContent = new HttpBodyContent(body: body, contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(body, (int)httpBodyContent.Body);
+        }
+
+        [Fact]
+        public void Ctor1_WithJsonGuidBody_SetsBodyAndContent()
+        {
+            Guid bodyIn = Guid.NewGuid();
+            string bodyOut = "\"" + bodyIn + "\"";
+            string content = "\"" + bodyIn + "\"";
+            var httpBodyContent = new HttpBodyContent(body: bodyIn, contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(bodyOut, (string)httpBodyContent.Body);
+        }
+
+        [Fact]
+        public void Ctor1_WithJsonObjectBodyAndTitleCasedContentType_SetsBodyAndContent()
         {
             var body = new
             {
@@ -131,7 +183,7 @@ namespace PactNet.Tests.Mocks.MockHttpService.Models
         }
 
         [Fact]
-        public void Ctor2_WithJsonContent_SetsBodyAndContent()
+        public void Ctor2_WithJsonObjectContent_SetsBodyAndContent()
         {
             var body = new
             {
@@ -144,6 +196,57 @@ namespace PactNet.Tests.Mocks.MockHttpService.Models
             Assert.Equal(content, httpBodyContent.Content);
             Assert.Equal(body.Test, (string)httpBodyContent.Body.Test);
             Assert.Equal(body.tesTer, (int)httpBodyContent.Body.tesTer);
+        }
+
+        [Fact]
+        public void Ctor2_WithJsonArrayContent_SetsBodyAndContent()
+        {
+            var body = new[] {
+                new {
+                    Test = "tester",
+                    tesTer = 1
+                }
+            };
+            const string content = "[{\"Test\":\"tester\",\"tesTer\":1}]";
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(content), contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(body[0].Test, (string)httpBodyContent.Body[0].Test);
+            Assert.Equal(body[0].tesTer, (int)httpBodyContent.Body[0].tesTer);
+        }
+
+        [Fact]
+        public void Ctor2_WithJsonStringContent_SetsBodyAndContent()
+        {
+            const string body = "\"Some json string body\"";
+            const string content = "\"Some json string body\"";
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(content), contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(body, (string)httpBodyContent.Body);
+        }
+
+        [Fact]
+        public void Ctor2_WithJsonIntContent_SetsBodyAndContent()
+        {
+            const int body = 5;
+            const string content = "5";
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(content), contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(body, (int)httpBodyContent.Body);
+        }
+
+        [Fact]
+        public void Ctor2_WithJsonGuidContent_SetsBodyAndContent()
+        {
+            var g = Guid.NewGuid();
+            string body = "\"" + g + "\"";
+            string content = "\"" + g + "\"";
+            var httpBodyContent = new HttpBodyContent(content: Encoding.UTF8.GetBytes(content), contentType: new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" });
+
+            Assert.Equal(content, httpBodyContent.Content);
+            Assert.Equal(body, (string)httpBodyContent.Body);
         }
 
         [Fact]

--- a/PactNet/Mocks/MockHttpService/Models/HttpBodyContent.cs
+++ b/PactNet/Mocks/MockHttpService/Models/HttpBodyContent.cs
@@ -59,7 +59,7 @@ namespace PactNet.Mocks.MockHttpService.Models
             if (IsJsonContentType())
             {
                 Content = JsonConvert.SerializeObject(body, JsonConfig.ApiSerializerSettings);
-                Body = IsJsonObjectOrArray(Content) ? body : Content;
+                Body = IsJsonString(Content) ? Content : body;
             }
             else if (IsBinaryContentType())
             {
@@ -94,7 +94,7 @@ namespace PactNet.Mocks.MockHttpService.Models
 
             if (IsJsonContentType())
             {
-                Body = IsJsonObjectOrArray(stringContent) ? JsonConvert.DeserializeObject<dynamic>(stringContent) : stringContent;
+                Body = IsJsonString(stringContent) ? stringContent : JsonConvert.DeserializeObject<dynamic>(stringContent);
             }
             else if (IsBinaryContentType())
             {
@@ -118,12 +118,13 @@ namespace PactNet.Mocks.MockHttpService.Models
                 ContentType.MediaType.IndexOf("octet-stream", StringComparison.InvariantCultureIgnoreCase) > 0;
         }
 
-        private bool IsJsonObjectOrArray(string stringContent)
+        private bool IsJsonString(string stringContent)
         {
-            var s = stringContent.Trim();
-
-            return (s.StartsWith("{", StringComparison.InvariantCultureIgnoreCase) && s.EndsWith("}", StringComparison.InvariantCultureIgnoreCase)) ||
-                (s.StartsWith("[", StringComparison.InvariantCultureIgnoreCase) && s.EndsWith("]", StringComparison.InvariantCultureIgnoreCase));
+            //Json string data types get serialized/deserialized differently than other non-string types,
+            //and so we have to make sure to preserve the extra double-quotes.
+            //Serialization Guide: http://www.newtonsoft.com/json/help/html/SerializationGuide.htm
+            return stringContent.StartsWith("\"", StringComparison.InvariantCultureIgnoreCase) &&
+                stringContent.EndsWith("\"", StringComparison.InvariantCultureIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
# Overview
Data serialized to json can take a couple different forms depending on whether you have an object, array, string, or number.  These changes fix how "string-like" data is serialized/deserialized in the request/response "body" of a pact interaction when the "Content-Type" header of the body is "application/json".  For example, below is what an interaction request/response "body" would look like before/after this fix for "string-like" data.

### Pact before fix:
`"headers": { "Content-Type": "application/json; charset=utf-8" },`
`"body": "Hello World"`

### Pact after fix:
`"headers": { "Content-Type": "application/json; charset=utf-8" },`
`"body": "\"Hello World\""`

# My Scenario That Surfaced The Issue
I have a .NET backend webservice endpoint that returns a single guid or url (it could also be any other .NET primitive that is convertible to a json string as described in the [Json.Net Serialization Guide](http://www.newtonsoft.com/json/help/html/SerializationGuide.htm)).  When I call that endpoint from my Javascript frontend, I get a simple json response as a double-quoted string.  In my frontend, I create e2e tests that use [Pact JS](https://github.com/pact-foundation/pact-js) to generate a pact file.  In that pact file, I end up with a response body like `"body": "\"https://...\""` because the frontend needs the body to be valid json when it processes the response.  When I tried to run that pact file through my .NET backend webservice using PactNet, the actual would never match the expected result because of how PactNet was stripping away the extra double-quotes that are essential to properly serialize/deserialize json strings.