### PR TITLE
Update PactVerifier to allow for publishing results

### DIFF
--- a/PactNet.Tests/Core/PactVerifierHostConfigTests.cs
+++ b/PactNet.Tests/Core/PactVerifierHostConfigTests.cs
@@ -98,6 +98,24 @@ namespace PactNet.Tests.Core
         }
 
         [Fact]
+        public void Ctor_WhenCalledWithPublishVerificationResults_SetsTheCorrectArgs()
+        {
+            var baseUri = new Uri("http://127.0.0.1");
+            var pactUri = "./tester-pact/pact-file.json";
+            var providerStateSetupUri = new Uri("http://127.0.0.1/states/");
+
+            var verifierConfig = new PactVerifierConfig();
+            verifierConfig.PublishVerificationResults = true;
+            verifierConfig.ProviderVersion = "1.0.0";
+
+            var config = GetSubject(baseUri: baseUri, pactUri: pactUri, providerStateSetupUri: providerStateSetupUri, verifierConfig: verifierConfig);
+
+            var expectedArguments = BuildExpectedArguments(baseUri, pactUri, providerStateSetupUri, publishVerificationResults: true, providerVersion: "1.0.0");
+
+            Assert.Equal(expectedArguments, config.Arguments);
+        }
+
+        [Fact]
         public void Ctor_WhenVerifierConfigIsNull_SetsOutputtersToNull()
         {
             var config = GetSubject();
@@ -109,12 +127,15 @@ namespace PactNet.Tests.Core
             Uri baseUri, 
             string pactUri, 
             Uri providerStateSetupUri,
-            PactUriOptions pactUriOptions = null)
+            PactUriOptions pactUriOptions = null,
+            bool publishVerificationResults = false,
+            string providerVersion = "")
         {
             var providerStateOption = providerStateSetupUri != null ? $" --provider-states-setup-url {providerStateSetupUri.OriginalString}" : "";
             var brokerCredentials = pactUriOptions != null ? $" --broker-username \"{pactUriOptions.Username}\" --broker-password \"{pactUriOptions.Password}\"" : "";
+            var publishResults = publishVerificationResults ? $" --publish-verification-results=true --provider-app-version=\"{providerVersion}\"" : string.Empty;
 
-            return $"--pact-urls \"{pactUri}\" --provider-base-url {baseUri.OriginalString}{providerStateOption}{brokerCredentials}";
+            return $"--pact-urls \"{pactUri}\" --provider-base-url {baseUri.OriginalString}{providerStateOption}{brokerCredentials}{publishResults}";
         }
     }
 }

--- a/PactNet.Tests/PactVerifierTests.cs
+++ b/PactNet.Tests/PactVerifierTests.cs
@@ -16,6 +16,16 @@ namespace PactNet.Tests
         }
 
         [Fact]
+        public void PactVerifier_WhenCalledWithPublishVerificationResultsAndNoProviderVersion_ThrowsArgumentException()
+        {
+            var config = new PactVerifierConfig();
+            config.PublishVerificationResults = true;
+            config.ProviderVersion = string.Empty;
+
+            Assert.Throws<ArgumentException>(() => new PactVerifier(config));
+        }
+
+        [Fact]
         public void ProviderState_WhenCalledWithSetupUri_SetsProviderStateSetupUri()
         {
             const string providerStateSetupUri = "http://localhost:223/states";

--- a/PactNet/Core/PactVerifierHostConfig.cs
+++ b/PactNet/Core/PactVerifierHostConfig.cs
@@ -15,9 +15,15 @@ namespace PactNet.Core
         {
             var providerStateOption = providerStateSetupUri != null ? $" --provider-states-setup-url {providerStateSetupUri.OriginalString}" : "";
             var brokerCredentials = pactBrokerUriOptions != null ? $" --broker-username \"{pactBrokerUriOptions.Username}\" --broker-password \"{pactBrokerUriOptions.Password}\"" : "";
-
+            string publishResults = string.Empty;
+            
+            if (config?.PublishVerificationResults == true)
+            {
+                publishResults = $" --publish-verification-results=true --provider-app-version=\"{config.ProviderVersion}\"";
+            }
+            
             Script = "pact-provider-verifier.rb";
-            Arguments = $"--pact-urls \"{FixPathForRuby(pactUri)}\" --provider-base-url {baseUri.OriginalString}{providerStateOption}{brokerCredentials}";
+            Arguments = $"--pact-urls \"{FixPathForRuby(pactUri)}\" --provider-base-url {baseUri.OriginalString}{providerStateOption}{brokerCredentials}{publishResults}";
             WaitForExit = true;
             Outputters = config?.Outputters;
         }

--- a/PactNet/PactVerifier.cs
+++ b/PactNet/PactVerifier.cs
@@ -27,6 +27,10 @@ namespace PactNet
             hostConfig => new PactCoreHost<PactVerifierHostConfig>(hostConfig), 
             config ?? new PactVerifierConfig())
         {
+            if (config.PublishVerificationResults && string.IsNullOrEmpty(config.ProviderVersion))
+            {
+                throw new ArgumentException($"{nameof(config.ProviderVersion)} is required when {nameof(config.PublishVerificationResults)} is true.");
+            }
         }
 
         public IPactVerifier ProviderState(string providerStateSetupUri)

--- a/PactNet/PactVerifierConfig.cs
+++ b/PactNet/PactVerifierConfig.cs
@@ -6,6 +6,10 @@ namespace PactNet
     public class PactVerifierConfig
     {
         public IEnumerable<IOutput> Outputters { get; set; }
+        
+        public bool PublishVerificationResults { get; set; }
+
+        public string ProviderVersion { get; set; }
 
         public PactVerifierConfig()
         {


### PR DESCRIPTION
Per Issue #99

I added two properties on the PactVerifierConfig object and added them to the arguments generated in PactVerifierHostConfig.

I used the optional parameters from `pact-provider-verifier.bat --help verify`

![image](https://user-images.githubusercontent.com/539365/28432620-62dd9230-6d3d-11e7-90aa-c2a316ce8b25.png)