### PR TITLE
feat!: Ensure work-in-progress is a proper date in the format expected by the FFI

### DIFF
--- a/samples/ReadMe/Provider.Tests/SomethingApiFixture.cs
+++ b/samples/ReadMe/Provider.Tests/SomethingApiFixture.cs
@@ -12,7 +12,7 @@ namespace ReadMe.Provider.Tests
 
         public SomethingApiFixture()
         {
-            ServerUri = new Uri("http://localhost:9222");
+            ServerUri = new Uri("http://localhost:9223");
             server = Host.CreateDefaultBuilder()
                         .ConfigureWebHostDefaults(webBuilder =>
                         {

--- a/src/PactNet.Native/Verifier/NativePactBrokerOptions.cs
+++ b/src/PactNet.Native/Verifier/NativePactBrokerOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using PactNet.Native.Internal;
@@ -79,9 +80,10 @@ namespace PactNet.Native.Verifier
         /// </summary>
         /// <param name="date">WIP cut-off date</param>
         /// <returns>Fluent builder</returns>
-        public IPactBrokerOptions IncludeWipPactsSince(string date)
+        public IPactBrokerOptions IncludeWipPactsSince(DateTime date)
         {
-            this.verifierArgs.AddOption("--include-wip-pacts-since", date, nameof(date));
+            string formatted = date.Date.ToString("yyyy-MM-dd");
+            this.verifierArgs.AddOption("--include-wip-pacts-since", formatted, nameof(date));
 
             return this;
         }

--- a/src/PactNet/Verifier/IPactBrokerOptions.cs
+++ b/src/PactNet/Verifier/IPactBrokerOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace PactNet.Verifier
 {
     /// <summary>
@@ -38,7 +40,7 @@ namespace PactNet.Verifier
         /// </summary>
         /// <param name="date">WIP cut-off date</param>
         /// <returns>Fluent builder</returns>
-        IPactBrokerOptions IncludeWipPactsSince(string date); // TODO: Should this be a DateTime or DateTimeOffset so we can format it properly?
+        IPactBrokerOptions IncludeWipPactsSince(DateTime date);
 
         /// <summary>
         /// Publish results to the pact broker

--- a/tests/PactNet.Native.Tests/Verifier/NativePactBrokerOptionsTests.cs
+++ b/tests/PactNet.Native.Tests/Verifier/NativePactBrokerOptionsTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FluentAssertions;
+using FluentAssertions.Extensions;
 using PactNet.Native.Verifier;
 using Xunit;
 
@@ -55,9 +56,9 @@ namespace PactNet.Native.Tests.Verifier
         [Fact]
         public void FromPactBroker_IncludeWipSince_AddsPactBrokerPendingArgs()
         {
-            this.options.IncludeWipPactsSince("5d");
+            this.options.IncludeWipPactsSince(14.February(2021));
 
-            this.verifierArgs.Should().Contain("--include-wip-pacts-since", "5d");
+            this.verifierArgs.Should().Contain("--include-wip-pacts-since", "2021-02-14");
         }
 
         [Fact]


### PR DESCRIPTION
Note: the port change in one of the samples is to prevent a potential CI failure because 2 of the samples were using the same port. It's made the CI fail on the Mac build before.