### PR TITLE
feat: Add consumer version selectors to verifier (closes #336)

### DIFF
--- a/src/PactNet.Abstractions/Verifier/ConsumerVersionSelector.cs
+++ b/src/PactNet.Abstractions/Verifier/ConsumerVersionSelector.cs
@@ -1,0 +1,68 @@
+namespace PactNet.Verifier
+{
+    /// <summary>
+    /// Consumer version selector
+    /// </summary>
+    /// <remarks>See <see href="https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors"/></remarks>
+    public class ConsumerVersionSelector
+    {
+        /// <summary>
+        /// Select pacts from the main branch of the consumer
+        /// </summary>
+        public bool MainBranch { get; set; }
+
+        /// <summary>
+        /// Select pacts which have the same branch as the current provider branch
+        /// </summary>
+        public bool MatchingBranch { get; set; }
+
+        /// <summary>
+        /// Select pacts from the given branch
+        /// </summary>
+        public string Branch { get; set; }
+
+        /// <summary>
+        /// If the consumer doesn't have a branch which matches the <see cref="Branch"/> property, use this branch instead
+        /// </summary>
+        public string FallbackBranch { get; set; }
+
+        /// <summary>
+        /// Select pacts with the given tag
+        /// </summary>
+        /// <remarks>It is recommended that the <see cref="Branch"/> property is used instead</remarks>
+        public string Tag { get; set; }
+
+        /// <summary>
+        /// If the consumer doesn't have a tag which matches the <see cref="Tag"/> property, use this tag instead
+        /// </summary>
+        /// <remarks>It is recommended that the <see cref="FallbackBranch"/> property is used instead</remarks>
+        public string FallbackTag { get; set; }
+
+        /// <summary>
+        /// Only return consumer pacts which are deployed to an environment
+        /// </summary>
+        public bool Deployed { get; set; }
+
+        /// <summary>
+        /// Only return consumer pacts which are released and currently supported in any environment
+        /// </summary>
+        public bool Released { get; set; }
+
+        /// <summary>
+        /// Either <see cref="Deployed"/> or <see cref="Released"/> (whereas setting both of the other properties
+        /// would mean deployed AND released)
+        /// </summary>
+        public bool DeployedOrReleased { get; set; }
+
+        /// <summary>
+        /// Only return consumer pacts which match this environment, in conjunction with <see cref="Deployed"/> or <see cref="Released"/>
+        /// </summary>
+        public string Environment { get; set; }
+
+        /// <summary>
+        /// Only return the latest pact for a given branch or tag
+        /// </summary>
+        /// <remarks>This should not be set when used with a branch</remarks>
+        public bool? Latest { get; set; }
+    }
+}

--- a/src/PactNet.Abstractions/Verifier/IPactBrokerOptions.cs
+++ b/src/PactNet.Abstractions/Verifier/IPactBrokerOptions.cs
@@ -36,6 +36,14 @@ namespace PactNet.Verifier
         IPactBrokerOptions ConsumerTags(params string[] tags);
 
         /// <summary>
+        /// Consumer version selectors to control which pacts are returned from the broker
+        /// </summary>
+        /// <param name="selectors">Consumer version selectors</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>See <see href="https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors"/></remarks>
+        IPactBrokerOptions ConsumerVersionSelectors(params ConsumerVersionSelector[] selectors);
+
+        /// <summary>
         /// Include WIP pacts since the given date
         /// </summary>
         /// <param name="date">WIP cut-off date</param>

--- a/src/PactNet/Verifier/PactBrokerOptions.cs
+++ b/src/PactNet/Verifier/PactBrokerOptions.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using PactNet.Internal;
 
 namespace PactNet.Verifier
@@ -69,6 +71,29 @@ namespace PactNet.Verifier
             {
                 string versions = string.Join(",", tags);
                 this.verifierArgs.AddOption("--consumer-version-tags", versions);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Consumer version selectors to control which pacts are returned from the broker
+        /// </summary>
+        /// <param name="selectors">Consumer version selectors</param>
+        /// <returns>Fluent builder</returns>
+        /// <remarks>See <see href="https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors"/></remarks>
+        public IPactBrokerOptions ConsumerVersionSelectors(params ConsumerVersionSelector[] selectors)
+        {
+            if (selectors.Any())
+            {
+                string value = JsonConvert.SerializeObject(selectors, new JsonSerializerSettings
+                {
+                    DefaultValueHandling = DefaultValueHandling.Ignore,
+                    NullValueHandling = NullValueHandling.Ignore,
+                    ContractResolver = new CamelCasePropertyNamesContractResolver()
+                });
+
+                this.verifierArgs.AddOption("--consumer-version-selectors", value);
             }
 
             return this;

--- a/tests/PactNet.Tests/Verifier/PactBrokerOptionsTests.cs
+++ b/tests/PactNet.Tests/Verifier/PactBrokerOptionsTests.cs
@@ -54,6 +54,25 @@ namespace PactNet.Tests.Verifier
         }
 
         [Fact]
+        public void ConsumerVersionSelectors_WhenCalled_AddsConsumerVersionSelectorsArgs()
+        {
+            string expected = string.Join(",",
+                                          @"{""mainBranch"":true,""matchingBranch"":true}",
+                                          @"{""branch"":""feat/foo"",""fallbackBranch"":""main""}",
+                                          @"{""tag"":""foo"",""fallbackTag"":""bar"",""latest"":false}",
+                                          @"{""deployed"":true,""released"":true,""environment"":""prod""}",
+                                          @"{""deployedOrReleased"":true}");
+
+            this.options.ConsumerVersionSelectors(new ConsumerVersionSelector { MainBranch = true, MatchingBranch = true },
+                                                  new ConsumerVersionSelector { Branch = "feat/foo", FallbackBranch = "main" },
+                                                  new ConsumerVersionSelector { Tag = "foo", FallbackTag = "bar", Latest = false },
+                                                  new ConsumerVersionSelector { Released = true, Deployed = true, Environment = "prod" },
+                                                  new ConsumerVersionSelector { DeployedOrReleased = true });
+
+            this.verifierArgs.Should().Contain("--consumer-version-selectors", $"[{expected}]");
+        }
+
+        [Fact]
         public void FromPactBroker_IncludeWipSince_AddsPactBrokerPendingArgs()
         {
             this.options.IncludeWipPactsSince(14.February(2021));


### PR DESCRIPTION
Note: we don't need to support the `consumer` option for the selectors because that's handled outside of version selectors.