### PR TITLE
feat: linux musl detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,52 @@ jobs:
           name: nupkgs
           path: ./dist/*.*
 
+  build-dotnet-containers:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.arch }}-${{ matrix.distro }}-build-dotnet-container
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64 
+          # - arm64
+        distro:
+          - "mcr.microsoft.com/dotnet/sdk:8.0"
+          - "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20"
+          - "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker dependencies
+        id: docker_commands
+        shell: bash
+        run: |
+          if [[ ${{ matrix.distro }} == *"alpine"* ]]; then
+            echo "deps=apk add --no-cache curl bash gzip && " >> "$GITHUB_OUTPUT"
+          else
+            echo "deps=" >> "$GITHUB_OUTPUT"
+          fi
+  
+      - name: Restore, Build & Test
+        run: |
+          docker run \
+            --rm \
+            -v $(pwd):/${{ github.workspace }} \
+            -w ${{ github.workspace }} \
+            --platform linux/${{ matrix.arch }} \
+            --entrypoint /bin/sh \
+            ${{ matrix.distro }} \
+            -c '${{ steps.docker_commands.outputs.deps }} \
+            build/download-native-libs.sh && \
+            dotnet restore && dotnet build --no-restore && \
+            dotnet test --no-build --verbosity normal'      
+
   release:
-    needs: build-dotnet
+    needs: [
+      build-dotnet,
+      build-dotnet-containers
+      ]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,17 +74,19 @@ jobs:
 
   build-dotnet-containers:
     runs-on: ubuntu-latest
-    name: ${{ matrix.arch }}-${{ matrix.distro }}-build-dotnet-container
+    name: ${{ matrix.os }}-${{ matrix.distro }}-build-dotnet-container
     strategy:
       fail-fast: false
       matrix:
-        arch:
-          - amd64 
-          # - arm64
+        os: 
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         distro:
           - "mcr.microsoft.com/dotnet/sdk:8.0"
+          - "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.21"
           - "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.20"
           - "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.19"
+          - "mcr.microsoft.com/dotnet/sdk:8.0-alpine3.18"
 
     steps:
       - uses: actions/checkout@v4
@@ -105,7 +107,6 @@ jobs:
             --rm \
             -v $(pwd):/${{ github.workspace }} \
             -w ${{ github.workspace }} \
-            --platform linux/${{ matrix.arch }} \
             --entrypoint /bin/sh \
             ${{ matrix.distro }} \
             -c '${{ steps.docker_commands.outputs.deps }} \

--- a/README.md
+++ b/README.md
@@ -232,16 +232,16 @@ For writing messaging pacts instead of requests/response pacts, see the [messagi
 
 Due to using a shared native library instead of C# for the main Pact logic only certain OSs are supported:
 
-| OS           | Arch         | Support                                                            |
-| ------------ | ------------ | -------------------------------------------------------------------|
-| Windows      | x86          | ❌ No                                                              |
-| Windows      | x64          | ✔️ Yes                                                             |
-| Linux (libc) | ARM64        | ✔️ Yes                                                              |
-| Linux (libc) | x64          | ✔️ Yes                                                             |
-| Linux (libc) | x86          | ❌ No                                                              |
-| Linux (musl) | Any          | ❌ [No](https://github.com/pact-foundation/pact-net/issues/374)    |
-| OSX          | x64          | ✔️ Yes                                                             |
-| OSX          | ARM64 (M1/M2)| ✔️ Yes                                                             |
+| OS           | Arch        | Support                                                            |
+| ------------ | ----------- | -------------------------------------------------------------------|
+| Windows      | x86         | ❌ No                                                              |
+| Windows      | x64         | ✔️ Yes                                                              |
+| Linux (libc) | ARM         | ✔️ Yes                                                              |
+| Linux (libc) | x86         | ❌ No                                                              |
+| Linux (libc) | x64         | ✔️ Yes                                                              |
+| Linux (musl) | Any         | ✔️ Yes                                                              |
+| OSX          | x64         | ✔️ Yes                                                              |
+| OSX          | ARM (M1/M2) | ✔️ Yes                                                              |
 
 ### Pact Specification
 

--- a/build/download-native-libs.sh
+++ b/build/download-native-libs.sh
@@ -46,7 +46,23 @@ download_native() {
     if [[ "$OSTYPE" == "darwin"* ]]; then
         shasum -a 256 --check --quiet "$src_sha"
     else
-        sha256sum --check --quiet "$src_sha"
+        if [[ "$OSTYPE" == "linux"* ]]; then
+            if ldd /bin/ls >/dev/null 2>&1; then
+                ldd_output=$(ldd /bin/ls)
+                case "$ldd_output" in
+                    *musl*) 
+                        sha256sum -c -s "$src_sha"
+                        ;;
+                    *) 
+                        sha256sum --check --quiet "$src_sha"
+                        ;;
+                esac
+            else
+                sha256sum --check --quiet "$src_sha"  
+            fi
+        else
+            sha256sum --check --quiet "$src_sha"
+        fi
     fi
 
     echo -e "${GREEN}OK${CLEAR}"
@@ -67,5 +83,7 @@ download_native "libpact_ffi" "linux" "x86_64" "so"
 download_native "libpact_ffi" "linux" "aarch64" "so"
 download_native "libpact_ffi" "macos" "x86_64" "dylib"
 download_native "libpact_ffi" "macos" "aarch64" "dylib"
+download_native "libpact_ffi" "linux" "x86_64-musl" "so"
+download_native "libpact_ffi" "linux" "aarch64-musl" "so"
 
 echo "Successfully downloaded FFI libraries"

--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" InitialTargets="build_libs">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,56 +9,84 @@
   </PropertyGroup>
 
   <Import Project="../NuGet.targets" />
+  <Target Name="build_libs">
+    <!-- musl detection notes -->
+    <!-- Main fallback behaviour is to default to glibc flavour, ensuring miminal impact on existing supported targets -->
+    <!-- ContinueOnError True and Fallback to IsLinuxX64 / IsLinuxArm64  -->
+    <!-- 1. Check host is Linux - IsLinux -->
+    <!-- 2. Check if supported arch specific musl lib exists - IsLinuxMuslX64LibFound/IsLinuxMuslArm64LibFound  -->
+    <!-- 3. Check if musl is the loaded libc -->
+    <!-- 3a. glibc hosts could have musl cross libs installed, in the standard musl location -->
+    <!-- 3b. use ldd on a well known binary such as /bin/sh and grep for musl -->
+    <!-- 3c. note ldd may not be available on all musl targets -->
+    <PropertyGroup>
+      <IsLinux>False</IsLinux>
+      <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'True'">True</IsLinux>
+      <IsLinuxMuslX64LibFound Condition="$([System.IO.File]::Exists('/lib/ld-musl-x86_64.so.1')) == 'True'">True</IsLinuxMuslX64LibFound>
+      <IsLinuxMuslArm64LibFound Condition="$([System.IO.File]::Exists('/lib/ld-musl-aarch64.so.1')) == 'True'">True</IsLinuxMuslArm64LibFound>
+    </PropertyGroup>
+    <!-- only run this check if linux and the musl shared libs were found -->
+    <Exec Command="ldd /bin/sh | grep musl" ConsoleToMSBuild="true" StandardOutputImportance="low" ContinueOnError="true" Condition="$(IsLinux) == 'True' And ($(IsLinuxMuslX64LibFound) == 'True' Or $(IsLinuxMuslArm64LibFound) == 'True')">
+        <Output TaskParameter="ExitCode" PropertyName="IsLinuxMuslLoaded"/>
+    </Exec>
+    <PropertyGroup>
+      <IsWindows>False</IsWindows>
+      <IsOSX>False</IsOSX>
+      <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'True'">True</IsWindows>
+      <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'True'">True</IsOSX>
+      <IsArm64>False</IsArm64>
+      <IsArm64 Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">True</IsArm64>
+      <IsLinuxX64 Condition="'$(IsLinux)' == 'True' And '$(IsArm64)' == 'False'">True</IsLinuxX64>
+      <IsLinuxArm64 Condition="'$(IsLinux)' == 'True' And '$(IsArm64)' == 'True'">True</IsLinuxArm64>
+      <IsLinuxMuslX64 Condition="'$(IsLinux)' == 'True' And '$(IsLinuxMuslLoaded)' == '0' And '$(IsArm64)' == 'False'">True</IsLinuxMuslX64>
+      <IsLinuxMuslArm64 Condition="'$(IsLinux)' == 'True' And '$(IsLinuxMuslLoaded)' == '0' And '$(IsArm64)' == 'True'">True</IsLinuxMuslArm64>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <IsWindows>False</IsWindows>
-    <IsLinux>False</IsLinux>
-    <IsOSX>False</IsOSX>
-    <IsArm64>False</IsArm64>
-    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'True'">True</IsWindows>
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'True'">True</IsLinux>
-    <IsOSX Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' == 'True'">True</IsOSX>
-    <IsArm64 Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">True</IsArm64>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\windows\x86_64\pact_ffi.dll">
-      <Link>pact_ffi.dll</Link>
-      <PackagePath>runtimes/win-x64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsWindows)'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64\libpact_ffi.so">
-      <Link>libpact_ffi.so</Link>
-      <PackagePath>runtimes/linux-x64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsLinux)' And '$(IsArm64)' == 'False'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\aarch64\libpact_ffi.so">
-      <Link>libpact_ffi.so</Link>
-      <PackagePath>runtimes/linux-arm64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsLinux)' And '$(IsArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\macos\x86_64\libpact_ffi.dylib">
-      <Link>libpact_ffi.dylib</Link>
-      <PackagePath>runtimes/osx-x64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsOSX)' == 'True' And '$(IsArm64)' == 'False'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\build\macos\aarch64\libpact_ffi.dylib">
-      <Link>libpact_ffi.dylib</Link>
-      <PackagePath>runtimes/osx-arm64/native</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory Condition="'$(IsOSX)' == 'True' And '$(IsArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </Content>
-  </ItemGroup>
-
+    <ItemGroup>
+      <Content Include="$(MSBuildProjectDirectory)\..\..\build\windows\x86_64\pact_ffi.dll">
+        <Link>pact_ffi.dll</Link>
+        <PackagePath>runtimes/win-x64/native</PackagePath>
+        <Pack>true</Pack>
+        <CopyToOutputDirectory Condition="'$(IsWindows)'">PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+      </Content>
+      <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64\libpact_ffi.so">
+        <Link>libpact_ffi.so</Link>
+        <PackagePath>runtimes/linux-x64/native</PackagePath>
+        <Pack>true</Pack>
+        <CopyToOutputDirectory Condition="'$(IsLinuxX64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+      </Content>
+      <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64-musl\libpact_ffi.so">
+        <Link>libpact_ffi.so</Link>
+        <PackagePath>runtimes/linux-x64-musl/native</PackagePath>
+        <Pack>true</Pack>
+        <CopyToOutputDirectory Condition="'$(IsLinuxMuslX64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+      </Content>
+      <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\aarch64-musl\libpact_ffi.so">
+        <Link>libpact_ffi.so</Link>
+        <PackagePath>runtimes/linux-arm64-musl/native</PackagePath>
+        <Pack>true</Pack>
+        <CopyToOutputDirectory Condition="'$(IsLinuxMuslArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+      </Content>
+      <Content Include="$(MSBuildProjectDirectory)\..\..\build\macos\x86_64\libpact_ffi.dylib">
+        <Link>libpact_ffi.dylib</Link>
+        <PackagePath>runtimes/osx-x64/native</PackagePath>
+        <Pack>true</Pack>
+        <CopyToOutputDirectory Condition="'$(IsOSX)' == 'True' And '$(IsArm64)' == 'False'">PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+      </Content>
+      <Content Include="$(MSBuildProjectDirectory)\..\..\build\macos\aarch64\libpact_ffi.dylib">
+        <Link>libpact_ffi.dylib</Link>
+        <PackagePath>runtimes/osx-arm64/native</PackagePath>
+        <Pack>true</Pack>
+        <CopyToOutputDirectory Condition="'$(IsOSX)' == 'True' And '$(IsArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+      </Content>
+    </ItemGroup>
+  </Target>
   <ItemGroup>
     <Content Include="$(MSBuildProjectDirectory)\..\..\build\PactNet.targets">
       <PackagePath>build/net462/</PackagePath>

--- a/src/PactNet/PactNet.csproj
+++ b/src/PactNet/PactNet.csproj
@@ -57,6 +57,13 @@
         <CopyToOutputDirectory Condition="'$(IsLinuxX64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
         <Visible>false</Visible>
       </Content>
+      <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\aarch64\libpact_ffi.so">
+        <Link>libpact_ffi.so</Link>
+        <PackagePath>runtimes/linux-arm64/native</PackagePath>
+        <Pack>true</Pack>
+        <CopyToOutputDirectory Condition="'$(IsLinuxArm64)' == 'True'">PreserveNewest</CopyToOutputDirectory>
+        <Visible>false</Visible>
+      </Content>
       <Content Include="$(MSBuildProjectDirectory)\..\..\build\linux\x86_64-musl\libpact_ffi.so">
         <Link>libpact_ffi.so</Link>
         <PackagePath>runtimes/linux-x64-musl/native</PackagePath>


### PR DESCRIPTION
## Rationale

pact-reference has introduced musl and arm64 based ffi libraries for linux

- https://github.com/pact-foundation/pact-reference/issues/416

Tracking Issue

- https://github.com/pact-foundation/devrel/issues/30

## Issues Resolved

fixes #498
fixes #496
fixes #500
fixes #374
fixes #387

## Backwards Compatibility

Linux glibc based hosts take precedence, so if any error occurs during musl detection. I do not anticipate breaking changes for users

## Implementation notes

### .NET notes

- Docs
  - [Uses MSBuild Exec task](https://learn.microsoft.com/en-us/visualstudio/msbuild/exec-task?view=vs-2022)
- MSBuild Blog Posts
  - [Cross-Platform Build Events in .NET Core using MSBuild](https://jeremybytes.blogspot.com/2020/05/cross-platform-build-events-in-net-core.html)
  - [MSBuild 101: Using the exit code from a command](https://www.creepingcoder.com/2020/06/01/msbuild-101-using-the-exit-code-from-a-command/)
- Stack OverFlow
  - [Set PropertyGroup property to Exec output](https://stackoverflow.com/questions/76583824/set-propertygroup-property-to-exec-output)
- .NET runtime musl detection code
  - https://github.com/dotnet/runtime/blob/a50ba0669353893ca8ade8568b0a7d210b5a425f/src/mono/llvm/llvm-init.proj\#L7
  - https://github.com/dotnet/runtime/blob/a50ba0669353893ca8ade8568b0a7d210b5a425f/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs\#L78t

### Conditions for execution

musl detection will run if

- if linux
- if /lib/ld-musl-(x86_64|aarch64).so.1 exists
- if ldd bin/sh | grep musl is true (musl lib is loaded, rather than glibc)

will continue on error, reverting back to glibc based libaries.

### Supported musl targets

should work for multiple musl based distroes if

- /lib/ld-musl-(x86_64|aarch64).so.1 exists
- ldd is available (available by default in alpine images)

Tested on Alpine ARM64 / AMD64.

## Caveats

- [.NET does not run under QEMU](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md#qemu) affecting the ability to test multi-arch from a single system
- .NET restore can take a long time when running under containers.
  - [Workaround](https://github.com/NuGet/Home/issues/13062#issuecomment-1845202196): Set `DOTNET_NUGET_SIGNATURE_VERIFICATION` to `false`

## Compatibility

### Operating System

Due to using a shared native library instead of C# for the main Pact logic only certain OSs are supported:

| OS           | Arch        | Support                                                            |
| ------------ | ----------- | -------------------------------------------------------------------|
| Windows      | x86         | ❌ No                                                              |
| Windows      | x64         | ✔️ Yes                                                              |
| Linux (libc) | x86         | ❌ No                                                              |
| Linux (libc) | x64         | ✔️ Yes                                                              |
| Linux (musl) | x64         | ✔️ Yes                                                   |
| Linux (libc) | ARM         | ✔️ Yes                                                  |
| Linux (musl) | ARM         | ✔️ Yes                                             |
| OSX          | x64         | ✔️ Yes                                                              |
| OSX          | ARM (M1/M2) | ✔️ Yes                                                              |
