### PR TITLE
docs: point to new workshop link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Watch our [series](https://www.youtube.com/playlist?list=PLwy9Bnco-IpfZ72VQ7hce8
 
 ### Tutorial (60 minutes)
 
-[Learn everything in Pact Net in 60 minutes](https://github.com/DiUS/pact-workshop-dotnet-core-v3/)
+[Learn everything in Pact Net in 60 minutes](https://github.com/pact-foundation/pact-workshop-dotnet)
 
 ### Upgrade Guides
 


### PR DESCRIPTION
The DiUS pact-net workshop is out of date.

We have created a new repo under the pact-foundation org 

https://github.com/pact-foundation/pact-workshop-dotnet

which is a hard fork but applies updates to Pact-Net 4.5.x / .NET 6

It at least puts it under our control for maintenance so we can update in a timely fashion and apply contributions from the community